### PR TITLE
feat: GridRiverLakeSediment module for sediment transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ lib
 *.a
 *.x
 *.log
+.worktrees/

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ OBJS_BASIC =    \
 				 MOD_Grid_RiverLakeNetwork.o    \
 				 MOD_Grid_Reservoir.o           \
 				 MOD_Grid_RiverLakeTimeVars.o   \
+				 MOD_Grid_RiverLakeSediment.o   \
 				 MOD_BGC_Vars_1DFluxes.o        \
 				 MOD_BGC_Vars_1DPFTFluxes.o     \
 				 MOD_BGC_Vars_PFTimeVariables.o \

--- a/docs/plans/2025-12-24-grid-riverlake-sediment-design.md
+++ b/docs/plans/2025-12-24-grid-riverlake-sediment-design.md
@@ -1,0 +1,356 @@
+# GridRiverLakeSediment 模块设计文档
+
+**日期：** 2025-12-24
+**目标：** 将 CaMa-Flood 泥沙模块移植到 GridRiverLakeFlow 框架中
+
+---
+
+## 1. 概述
+
+### 1.1 背景
+
+泥沙模块已在 CaMa-Flood (`extends/CaMa/src/cmf_ctrl_sed_mod.F90`) 中实现，需要移植到 GridRiverLakeFlow 框架中，使其能够在定义 GridRiverLakeFlow 时使用并输出相关结果。
+
+### 1.2 数据来源
+
+静态数据已保存在 `DEF_UnitCatchment_file` (如 `grid_routing_data.nc`) 中：
+- `sed_frc(nseqmax, sed_n)` - 泥沙粒径分布比例，3个粒径级别
+- `sed_slope(nseqmax, slope_layers)` - 坡面坡度，10层
+
+### 1.3 设计决策
+
+| 决策项 | 选择 |
+|--------|------|
+| 移植范围 | 完整移植（悬沙、推移质、侵蚀产沙、沉积层交换） |
+| 产沙驱动 | 降水驱动（类似 CaMa-Flood） |
+| 时间步长 | 独立子循环（与水流时间步分离） |
+| 输出变量 | 完整变量（包括诊断变量） |
+| 代码组织 | 独立模块 `MOD_Grid_RiverLakeSediment.F90` |
+
+---
+
+## 2. 模块架构
+
+### 2.1 新建文件
+
+**`main/HYDRO/MOD_Grid_RiverLakeSediment.F90`**
+
+```
+MOD_Grid_RiverLakeSediment
+├── 参数常量
+│   ├── nsed (粒径级数，从NC文件读取)
+│   ├── totlyrnum (沉积层数)
+│   ├── 物理常数 (lambda, psedD, pwatD, visKin, vonKar等)
+│   └── 产沙参数 (pyld, pyldc, pyldpc, dsylunit)
+│
+├── 静态数据 (从 DEF_UnitCatchment_file 读取)
+│   ├── sed_frc(:,:)     - 泥沙粒径分布比例 [numucat, nsed]
+│   ├── sed_slope(:,:)   - 坡面坡度 [numucat, nlfp]
+│   └── sDiam(:)         - 各粒径直径 [nsed]
+│
+├── 状态变量
+│   ├── sedcon(:,:)      - 悬沙浓度 [numucat, nsed]
+│   ├── layer(:,:)       - 活动层泥沙量 [numucat, nsed]
+│   └── seddep(:,:,:)    - 沉积层泥沙量 [numucat, totlyrnum, nsed]
+│
+├── 诊断变量
+│   ├── sedout(:,:)      - 悬沙通量
+│   ├── bedout(:,:)      - 推移质通量
+│   ├── netflw(:,:)      - 净交换通量
+│   ├── sedinp(:,:)      - 侵蚀产沙输入
+│   └── shearvel(:), critshearvel(:,:), setvel(:)等
+│
+└── 累积输出变量 (用于历史输出)
+```
+
+### 2.2 修改文件清单
+
+| 文件 | 修改内容 |
+|------|----------|
+| `include/define.h` | 添加 `#define GridRiverLakeSediment` 预处理开关 |
+| `main/MOD_Namelist.F90` | 添加泥沙相关 namelist 参数 |
+| `main/HYDRO/MOD_Grid_RiverLakeNetwork.F90` | 添加 sed_frc, sed_slope 数据读取 |
+| `main/HYDRO/MOD_Grid_RiverLakeFlow.F90` | 添加泥沙模块调用点 |
+| `main/HYDRO/MOD_Grid_RiverLakeTimeVars.F90` | 添加泥沙状态变量的 restart 读写 |
+| `main/HYDRO/MOD_Grid_RiverLakeHist.F90` | 添加泥沙输出变量与写出逻辑 |
+| `Makefile` 或 CMake 配置 | 添加新模块编译 |
+
+---
+
+## 3. 初始化流程
+
+```fortran
+SUBROUTINE grid_sediment_init()
+   ! 1. 读取泥沙参数维度
+   !    - 从 DEF_UnitCatchment_file 读取 nsed (sed_n 维度)
+   !    - 从 DEF_UnitCatchment_file 读取 nlfp (slope_layers 维度)
+
+   ! 2. 读取静态数据 (使用 readin_riverlake_parameter 模式)
+   !    - sed_frc(numucat, nsed) ← 'sed_frc'
+   !    - sed_slope(numucat, nlfp) ← 'sed_slope'
+
+   ! 3. 设置粒径直径 (通过 namelist 或硬编码)
+   !    - sDiam(:) = [0.0002, 0.002, 0.02] ! 示例：粉砂、细砂、粗砂
+
+   ! 4. 计算沉降速度
+   !    - setvel(:) = calc_settling_velocity(sDiam, visKin, psedD, pwatD)
+
+   ! 5. 分配状态变量数组
+   !    - sedcon(numucat, nsed)
+   !    - layer(numucat, nsed)
+   !    - seddep(numucat, totlyrnum, nsed)
+
+   ! 6. 初始化状态变量
+   !    - 如有 restart 文件则读取
+   !    - 否则根据 sed_frc 和活动层厚度初始化：
+   !      layer(i,:) = lyrdph * topo_rivwth(i) * topo_rivlen(i) * sed_frc(i,:)
+END SUBROUTINE
+```
+
+### 3.1 Namelist 配置
+
+```fortran
+! 在 MOD_Namelist 中添加
+logical :: DEF_USE_SEDIMENT = .false.    ! 是否启用泥沙模块
+real(r8) :: DEF_SED_LAMBDA  = 0.4        ! 孔隙率
+real(r8) :: DEF_SED_LYRDPH  = 0.00005    ! 活动层厚度 [m]
+real(r8) :: DEF_SED_DENSITY = 2.65       ! 泥沙密度 [g/cm³]
+integer  :: DEF_SED_TOTLYRNUM = 5        ! 沉积层数
+character(len=256) :: DEF_SED_DIAMETER = "0.0002,0.002,0.02"  ! 粒径 [m]
+
+! 产沙参数
+real(r8) :: DEF_SED_PYLD    = 0.01       ! 产沙系数
+real(r8) :: DEF_SED_PYLDC   = 2.0        ! 坡度指数
+real(r8) :: DEF_SED_PYLDPC  = 2.0        ! 降水指数
+```
+
+---
+
+## 4. 核心计算流程
+
+### 4.1 主计算子程序
+
+```fortran
+SUBROUTINE grid_sediment_calc(deltime)
+   ! 输入: deltime - 水流计算的总时间步长
+
+   ! 1. 累积水流诊断变量
+   !    - 在每个水流子步调用 sediment_diag_accumulate()
+   !    - 累积 veloc_riv, wdsrf_ucat 用于后续平均
+
+   ! 2. 泥沙独立子循环
+   DO WHILE (sed_time_remaining > 0)
+
+      dt_sed = min(sed_time_remaining, DEF_SED_DT_MAX)
+
+      ! 2.1 计算平均水流变量
+      avg_veloc = acc_veloc / acc_time
+      avg_wdsrf = acc_wdsrf / acc_time
+
+      ! 2.2 计算泥沙输运参数
+      CALL calc_sediment_params(avg_veloc, avg_wdsrf, &
+           shearvel, critshearvel, susvel)
+
+      ! 2.3 悬沙与推移质平流输运
+      CALL calc_sediment_advection(dt_sed, &
+           sedcon, layer, sedout, bedout)
+
+      ! 2.4 侵蚀产沙 (降水驱动)
+      CALL calc_sediment_yield(precip, sed_slope, sedinp)
+
+      ! 2.5 悬浮-沉积交换
+      CALL calc_sediment_exchange(dt_sed, &
+           sedcon, layer, netflw)
+
+      ! 2.6 沉积层重分布
+      CALL calc_layer_redistribution(layer, seddep)
+
+      ! 2.7 更新累积输出变量
+      CALL sediment_diag_accumulate_output(dt_sed)
+
+      sed_time_remaining = sed_time_remaining - dt_sed
+   ENDDO
+END SUBROUTINE
+```
+
+### 4.2 关键物理计算函数
+
+| 函数 | 功能 | 公式来源 |
+|------|------|----------|
+| `calc_settling_velocity` | 沉降速度 | Stokes-Rubey 公式 |
+| `calc_shear_velocity` | 剪切流速 | Manning 公式 |
+| `calc_critical_shear` | 临界剪切力 | Shields / Egiazoroff 方程 |
+| `calc_suspend_velocity` | 悬浮速度 | Uchida & Fukuoka (2019) Eq.44 |
+
+### 4.3 上下游通信
+
+使用现有的 worker_push_data 机制：
+- `worker_push_data(push_next2ucat, ...)` - 获取下游泥沙浓度
+- `worker_push_data(push_ups2ucat, ...)` - 汇总上游泥沙通量
+
+---
+
+## 5. 模块集成
+
+### 5.1 在 MOD_Grid_RiverLakeFlow.F90 中的调用点
+
+```fortran
+SUBROUTINE grid_riverlake_flow(year, deltime)
+   ...
+   ! 在水流计算主循环中添加泥沙诊断累积
+   DO WHILE (any(dt_res > 0))
+      ...
+      ! 现有水流计算
+      ...
+
+#ifdef GridRiverLakeSediment
+      ! 每个水流子步累积泥沙所需的水流变量
+      IF (DEF_USE_SEDIMENT) THEN
+         CALL sediment_diag_accumulate(dt_all, veloc_riv, wdsrf_ucat)
+      ENDIF
+#endif
+      ...
+   ENDDO
+
+#ifdef GridRiverLakeSediment
+   ! 水流计算完成后，执行泥沙计算
+   IF (DEF_USE_SEDIMENT) THEN
+      CALL grid_sediment_calc(acctime_rnof)
+   ENDIF
+#endif
+   ...
+END SUBROUTINE
+```
+
+### 5.2 降水数据传递
+
+```fortran
+SUBROUTINE grid_sediment_forcing_put(precip_uc)
+   ! precip_uc: 单元集水区的降水量 [numucat]
+   sed_precip(:) = precip_uc(:)
+END SUBROUTINE
+```
+
+### 5.3 静态数据读取
+
+在 `MOD_Grid_RiverLakeNetwork.F90` 的 `build_riverlake_network()` 中添加：
+
+```fortran
+#ifdef GridRiverLakeSediment
+   IF (DEF_USE_SEDIMENT) THEN
+      CALL readin_riverlake_parameter(parafile, 'sed_frc',   rdata2d=sed_frc)
+      CALL readin_riverlake_parameter(parafile, 'sed_slope', rdata2d=sed_slope)
+   ENDIF
+#endif
+```
+
+### 5.4 Restart 支持
+
+在 `MOD_Grid_RiverLakeTimeVars.F90` 中添加：
+
+```fortran
+! READ
+CALL vector_read_and_scatter(file_restart, sedcon, numucat, 'sedcon', ucat_data_address)
+CALL vector_read_and_scatter(file_restart, layer,  numucat, 'layer',  ucat_data_address)
+! seddep 需要特殊处理 (3D数组)
+
+! WRITE
+CALL vector_gather_and_write(sedcon, numucat, totalnumucat, ucat_data_address, &
+   file_restart, 'sedcon', 'ucatch')
+```
+
+---
+
+## 6. 历史输出系统
+
+### 6.1 累积变量
+
+```fortran
+! 在 MOD_Grid_RiverLakeHist.F90 中添加
+real(r8), allocatable :: a_sedcon     (:,:)   ! 悬沙浓度 [numucat, nsed]
+real(r8), allocatable :: a_sedout     (:,:)   ! 悬沙通量 [numucat, nsed]
+real(r8), allocatable :: a_bedout     (:,:)   ! 推移质通量 [numucat, nsed]
+real(r8), allocatable :: a_sedinp     (:,:)   ! 侵蚀产沙量 [numucat, nsed]
+real(r8), allocatable :: a_netflw     (:,:)   ! 净交换通量 [numucat, nsed]
+real(r8), allocatable :: a_layer      (:,:)   ! 活动层存量 [numucat, nsed]
+real(r8), allocatable :: a_shearvel   (:)     ! 剪切流速 [numucat]
+real(r8), allocatable :: a_critshear  (:,:)   ! 临界剪切力 [numucat, nsed]
+```
+
+### 6.2 输出文件结构
+
+```
+历史文件 (*_unitcat_*.nc):
+├── 维度
+│   ├── time
+│   ├── lon_ucat, lat_ucat
+│   └── sed_class (新增，大小=nsed)
+│
+├── 坐标变量
+│   └── sed_diameter(sed_class)  ! 各粒径直径 [m]
+│
+└── 泥沙变量 (均为 [lon_ucat, lat_ucat, sed_class, time])
+    ├── f_sedcon      - 悬沙浓度 [m³/m³]
+    ├── f_sedout      - 悬沙通量 [m³/s]
+    ├── f_bedout      - 推移质通量 [m³/s]
+    ├── f_sedinp      - 侵蚀产沙 [m³/s]
+    ├── f_netflw      - 净交换通量 [m³/s]
+    ├── f_layer       - 活动层存量 [m³]
+    ├── f_shearvel    - 剪切流速 [m/s] (无sed_class维)
+    └── f_critshear   - 临界剪切力 [m/s]
+```
+
+### 6.3 输出控制 Namelist
+
+```fortran
+! 添加到 DEF_hist_vars
+logical :: sedcon    = .true.   ! 悬沙浓度
+logical :: sedout    = .true.   ! 悬沙通量
+logical :: bedout    = .true.   ! 推移质通量
+logical :: sedinp    = .true.   ! 侵蚀产沙
+logical :: netflw    = .true.   ! 净交换通量
+logical :: sedlayer  = .true.   ! 活动层存量
+logical :: shearvel  = .false.  ! 剪切流速 (诊断)
+logical :: critshear = .false.  ! 临界剪切力 (诊断)
+```
+
+---
+
+## 7. 实施步骤
+
+### 阶段一：框架搭建
+1. 创建 `MOD_Grid_RiverLakeSediment.F90` 模块框架
+2. 添加预处理开关 `GridRiverLakeSediment` 到 `define.h`
+3. 添加 namelist 参数到 `MOD_Namelist.F90`
+4. 实现静态数据读取（sed_frc, sed_slope）
+
+### 阶段二：核心计算
+1. 移植物理计算函数
+   - `calc_settling_velocity`
+   - `calc_shear_velocity`
+   - `calc_critical_shear`
+   - `calc_suspend_velocity`
+2. 实现平流输运计算 `calc_sediment_advection`
+3. 实现悬浮-沉积交换 `calc_sediment_exchange`
+4. 实现产沙计算 `calc_sediment_yield`
+5. 实现沉积层重分布 `calc_layer_redistribution`
+
+### 阶段三：集成测试
+1. 与 `MOD_Grid_RiverLakeFlow` 集成
+2. 添加历史输出到 `MOD_Grid_RiverLakeHist`
+3. 添加 restart 支持到 `MOD_Grid_RiverLakeTimeVars`
+4. 更新 Makefile/CMake 编译配置
+
+### 阶段四：验证
+1. 单点测试 - 验证物理计算正确性
+2. 区域测试 - 与 CaMa-Flood 泥沙结果对比
+3. 质量守恒检验
+
+---
+
+## 8. 参考资料
+
+- CaMa-Flood 泥沙模块源码: `extends/CaMa/src/cmf_ctrl_sed_mod.F90`
+- Uchida & Fukuoka (2019) - 悬浮速度公式
+- Egiazoroff 方程 - 混合粒径临界剪切力
+- Shields 曲线 - 单粒径临界剪切力

--- a/docs/plans/2025-12-24-grid-riverlake-sediment-implementation.md
+++ b/docs/plans/2025-12-24-grid-riverlake-sediment-implementation.md
@@ -1,0 +1,1603 @@
+# GridRiverLakeSediment 模块实施计划
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 将 CaMa-Flood 泥沙模块移植到 GridRiverLakeFlow 框架，实现完整的泥沙输运模拟。
+
+**Architecture:** 创建独立的 `MOD_Grid_RiverLakeSediment.F90` 模块，包含泥沙状态变量、物理计算和诊断输出。通过预处理开关 `GridRiverLakeSediment` 控制编译，通过运行时开关 `DEF_USE_SEDIMENT` 控制启用。泥沙计算在水流计算完成后执行，使用独立的时间子循环。
+
+**Tech Stack:** Fortran 90, NetCDF, MPI (可选)
+
+**Reference Design:** `docs/plans/2025-12-24-grid-riverlake-sediment-design.md`
+
+**Reference Implementation:** `extends/CaMa/src/cmf_ctrl_sed_mod.F90`
+
+---
+
+## Phase 1: 框架搭建
+
+### Task 1.1: 添加预处理开关
+
+**Files:**
+- Modify: `include/define.h`
+
+**Step 1: 查看现有预处理开关格式**
+
+```bash
+grep -n "GridRiverLake" include/define.h
+```
+
+**Step 2: 添加泥沙模块预处理开关**
+
+在 `#define GridRiverLakeFlow` 下方添加：
+
+```fortran
+#define GridRiverLakeSediment
+```
+
+**Step 3: 提交**
+
+```bash
+git add include/define.h
+git commit -m "feat: add GridRiverLakeSediment preprocessor switch"
+```
+
+---
+
+### Task 1.2: 添加 Namelist 参数
+
+**Files:**
+- Modify: `main/MOD_Namelist.F90`
+
+**Step 1: 查找 namelist 变量声明位置**
+
+```bash
+grep -n "DEF_Reservoir_Method" main/MOD_Namelist.F90 | head -5
+```
+
+**Step 2: 添加泥沙相关 namelist 变量声明**
+
+在水文相关变量声明区域添加：
+
+```fortran
+   ! Sediment module parameters
+   logical,  public :: DEF_USE_SEDIMENT     = .false.   ! Enable sediment module
+   real(r8), public :: DEF_SED_LAMBDA       = 0.4_r8    ! Porosity [-]
+   real(r8), public :: DEF_SED_LYRDPH       = 0.00005_r8 ! Active layer depth [m]
+   real(r8), public :: DEF_SED_DENSITY      = 2.65_r8   ! Sediment density [g/cm3]
+   real(r8), public :: DEF_SED_WATER_DENSITY = 1.0_r8   ! Water density [g/cm3]
+   real(r8), public :: DEF_SED_VISKIN       = 1.0e-6_r8 ! Kinematic viscosity [m2/s]
+   real(r8), public :: DEF_SED_VONKAR       = 0.4_r8    ! Von Karman coefficient [-]
+   integer,  public :: DEF_SED_TOTLYRNUM    = 5         ! Number of deposition layers
+   real(r8), public :: DEF_SED_DT_MAX       = 3600._r8  ! Max sediment timestep [s]
+   character(len=256), public :: DEF_SED_DIAMETER = "0.0002,0.002,0.02" ! Grain diameters [m]
+   ! Sediment yield parameters (Sunada & Hasegawa 1993)
+   real(r8), public :: DEF_SED_PYLD         = 0.01_r8   ! Yield coefficient
+   real(r8), public :: DEF_SED_PYLDC        = 2.0_r8    ! Slope exponent
+   real(r8), public :: DEF_SED_PYLDPC       = 2.0_r8    ! Precipitation exponent
+   real(r8), public :: DEF_SED_DSYLUNIT     = 1.0e-6_r8 ! Unit conversion factor
+```
+
+**Step 3: 查找 namelist 读取位置**
+
+```bash
+grep -n "DEF_Reservoir_Method" main/MOD_Namelist.F90 | grep -i "read\|nml"
+```
+
+**Step 4: 添加 namelist 读取**
+
+在相应的 namelist 组中添加读取逻辑（根据项目具体格式调整）。
+
+**Step 5: 提交**
+
+```bash
+git add main/MOD_Namelist.F90
+git commit -m "feat: add sediment module namelist parameters"
+```
+
+---
+
+### Task 1.3: 添加历史输出控制变量
+
+**Files:**
+- Modify: `main/MOD_Namelist.F90` (DEF_hist_vars 部分)
+
+**Step 1: 查找历史输出变量定义位置**
+
+```bash
+grep -n "discharge\|riv_height" main/MOD_Namelist.F90 | head -10
+```
+
+**Step 2: 添加泥沙输出控制变量**
+
+在 `DEF_hist_vars` 类型定义中添加：
+
+```fortran
+   ! Sediment output variables
+   logical :: sedcon    = .true.    ! Suspended sediment concentration
+   logical :: sedout    = .true.    ! Suspended sediment flux
+   logical :: bedout    = .true.    ! Bedload flux
+   logical :: sedinp    = .true.    ! Erosion/sediment input
+   logical :: netflw    = .true.    ! Net exchange flux
+   logical :: sedlayer  = .true.    ! Active layer storage
+   logical :: shearvel  = .false.   ! Shear velocity (diagnostic)
+   logical :: critshear = .false.   ! Critical shear velocity (diagnostic)
+```
+
+**Step 3: 提交**
+
+```bash
+git add main/MOD_Namelist.F90
+git commit -m "feat: add sediment history output control variables"
+```
+
+---
+
+### Task 1.4: 创建泥沙模块骨架
+
+**Files:**
+- Create: `main/HYDRO/MOD_Grid_RiverLakeSediment.F90`
+
+**Step 1: 创建模块基本结构**
+
+```fortran
+#include <define.h>
+
+#ifdef GridRiverLakeSediment
+MODULE MOD_Grid_RiverLakeSediment
+!-------------------------------------------------------------------------------------
+! DESCRIPTION:
+!
+!   Sediment transport module for GridRiverLakeFlow.
+!   Ported from CaMa-Flood sediment module (cmf_ctrl_sed_mod.F90)
+!
+! Created by: [Your Name], Dec 2025
+!-------------------------------------------------------------------------------------
+
+   USE MOD_Precision
+   USE MOD_SPMD_Task
+   USE MOD_Namelist
+   IMPLICIT NONE
+
+   !-------------------------------------------------------------------------------------
+   ! Module Parameters
+   !-------------------------------------------------------------------------------------
+   integer,  save :: nsed           ! Number of sediment size classes
+   integer,  save :: totlyrnum      ! Number of deposition layers
+   integer,  save :: nlfp_sed       ! Number of floodplain layers for slope
+
+   real(r8), save :: lambda         ! Porosity [-]
+   real(r8), save :: lyrdph         ! Active layer depth [m]
+   real(r8), save :: psedD          ! Sediment density [g/cm3]
+   real(r8), save :: pwatD          ! Water density [g/cm3]
+   real(r8), save :: visKin         ! Kinematic viscosity [m2/s]
+   real(r8), save :: vonKar         ! Von Karman coefficient [-]
+
+   ! Sediment yield parameters
+   real(r8), save :: pyld           ! Yield coefficient
+   real(r8), save :: pyldc          ! Slope exponent
+   real(r8), save :: pyldpc         ! Precipitation exponent
+   real(r8), save :: dsylunit       ! Unit conversion factor
+
+   !-------------------------------------------------------------------------------------
+   ! Static Data (read from DEF_UnitCatchment_file)
+   !-------------------------------------------------------------------------------------
+   real(r8), allocatable :: sed_frc   (:,:)    ! Sediment fraction [numucat, nsed]
+   real(r8), allocatable :: sed_slope (:,:)    ! Floodplain slope [numucat, nlfp]
+   real(r8), allocatable :: sDiam     (:)      ! Grain diameter [nsed]
+   real(r8), allocatable :: setvel    (:)      ! Settling velocity [nsed]
+
+   !-------------------------------------------------------------------------------------
+   ! State Variables
+   !-------------------------------------------------------------------------------------
+   real(r8), allocatable :: sedcon  (:,:)      ! Suspended sediment concentration [numucat, nsed]
+   real(r8), allocatable :: layer   (:,:)      ! Active layer storage [numucat, nsed]
+   real(r8), allocatable :: seddep  (:,:,:)    ! Deposition layer storage [numucat, totlyrnum, nsed]
+
+   !-------------------------------------------------------------------------------------
+   ! Diagnostic Variables
+   !-------------------------------------------------------------------------------------
+   real(r8), allocatable :: sedout  (:,:)      ! Suspended sediment outflow [numucat, nsed]
+   real(r8), allocatable :: bedout  (:,:)      ! Bedload outflow [numucat, nsed]
+   real(r8), allocatable :: sedinp  (:,:)      ! Erosion input [numucat, nsed]
+   real(r8), allocatable :: netflw  (:,:)      ! Net exchange flux [numucat, nsed]
+   real(r8), allocatable :: shearvel(:)        ! Shear velocity [numucat]
+   real(r8), allocatable :: critshearvel(:,:)  ! Critical shear velocity [numucat, nsed]
+   real(r8), allocatable :: susvel  (:,:)      ! Suspension velocity [numucat, nsed]
+
+   !-------------------------------------------------------------------------------------
+   ! Accumulated Variables for Sediment Time-stepping
+   !-------------------------------------------------------------------------------------
+   real(r8), save :: sed_acc_time              ! Accumulated time for averaging
+   real(r8), allocatable :: sed_acc_veloc(:)   ! Accumulated velocity [numucat]
+   real(r8), allocatable :: sed_acc_wdsrf(:)   ! Accumulated water depth [numucat]
+   real(r8), allocatable :: sed_precip(:)      ! Precipitation for sediment yield [numucat]
+
+   !-------------------------------------------------------------------------------------
+   ! Accumulated Variables for History Output
+   !-------------------------------------------------------------------------------------
+   real(r8), allocatable :: a_sedcon  (:,:)    ! Accumulated sedcon
+   real(r8), allocatable :: a_sedout  (:,:)    ! Accumulated sedout
+   real(r8), allocatable :: a_bedout  (:,:)    ! Accumulated bedout
+   real(r8), allocatable :: a_sedinp  (:,:)    ! Accumulated sedinp
+   real(r8), allocatable :: a_netflw  (:,:)    ! Accumulated netflw
+   real(r8), allocatable :: a_layer   (:,:)    ! Accumulated layer
+   real(r8), allocatable :: a_shearvel(:)      ! Accumulated shearvel
+
+   !-------------------------------------------------------------------------------------
+   ! Public Subroutines
+   !-------------------------------------------------------------------------------------
+   PUBLIC :: grid_sediment_init
+   PUBLIC :: grid_sediment_calc
+   PUBLIC :: grid_sediment_final
+   PUBLIC :: sediment_diag_accumulate
+   PUBLIC :: sediment_forcing_put
+
+CONTAINS
+
+   !-------------------------------------------------------------------------------------
+   SUBROUTINE grid_sediment_init()
+   ! Initialize sediment module
+   !-------------------------------------------------------------------------------------
+   IMPLICIT NONE
+      ! Placeholder - to be implemented
+      WRITE(*,*) 'MOD_Grid_RiverLakeSediment: grid_sediment_init called'
+   END SUBROUTINE grid_sediment_init
+
+   !-------------------------------------------------------------------------------------
+   SUBROUTINE grid_sediment_calc(deltime)
+   ! Main sediment calculation routine
+   !-------------------------------------------------------------------------------------
+   IMPLICIT NONE
+   real(r8), intent(in) :: deltime
+      ! Placeholder - to be implemented
+      WRITE(*,*) 'MOD_Grid_RiverLakeSediment: grid_sediment_calc called, dt=', deltime
+   END SUBROUTINE grid_sediment_calc
+
+   !-------------------------------------------------------------------------------------
+   SUBROUTINE sediment_diag_accumulate(dt, veloc, wdsrf)
+   ! Accumulate water flow variables for sediment calculation
+   !-------------------------------------------------------------------------------------
+   IMPLICIT NONE
+   real(r8), intent(in) :: dt
+   real(r8), intent(in) :: veloc(:)
+   real(r8), intent(in) :: wdsrf(:)
+      ! Placeholder - to be implemented
+   END SUBROUTINE sediment_diag_accumulate
+
+   !-------------------------------------------------------------------------------------
+   SUBROUTINE sediment_forcing_put(precip)
+   ! Store precipitation for sediment yield calculation
+   !-------------------------------------------------------------------------------------
+   IMPLICIT NONE
+   real(r8), intent(in) :: precip(:)
+      ! Placeholder - to be implemented
+   END SUBROUTINE sediment_forcing_put
+
+   !-------------------------------------------------------------------------------------
+   SUBROUTINE grid_sediment_final()
+   ! Cleanup sediment module
+   !-------------------------------------------------------------------------------------
+   IMPLICIT NONE
+      IF (allocated(sed_frc     )) deallocate(sed_frc     )
+      IF (allocated(sed_slope   )) deallocate(sed_slope   )
+      IF (allocated(sDiam       )) deallocate(sDiam       )
+      IF (allocated(setvel      )) deallocate(setvel      )
+      IF (allocated(sedcon      )) deallocate(sedcon      )
+      IF (allocated(layer       )) deallocate(layer       )
+      IF (allocated(seddep      )) deallocate(seddep      )
+      IF (allocated(sedout      )) deallocate(sedout      )
+      IF (allocated(bedout      )) deallocate(bedout      )
+      IF (allocated(sedinp      )) deallocate(sedinp      )
+      IF (allocated(netflw      )) deallocate(netflw      )
+      IF (allocated(shearvel    )) deallocate(shearvel    )
+      IF (allocated(critshearvel)) deallocate(critshearvel)
+      IF (allocated(susvel      )) deallocate(susvel      )
+      IF (allocated(sed_acc_veloc)) deallocate(sed_acc_veloc)
+      IF (allocated(sed_acc_wdsrf)) deallocate(sed_acc_wdsrf)
+      IF (allocated(sed_precip  )) deallocate(sed_precip  )
+      IF (allocated(a_sedcon    )) deallocate(a_sedcon    )
+      IF (allocated(a_sedout    )) deallocate(a_sedout    )
+      IF (allocated(a_bedout    )) deallocate(a_bedout    )
+      IF (allocated(a_sedinp    )) deallocate(a_sedinp    )
+      IF (allocated(a_netflw    )) deallocate(a_netflw    )
+      IF (allocated(a_layer     )) deallocate(a_layer     )
+      IF (allocated(a_shearvel  )) deallocate(a_shearvel  )
+   END SUBROUTINE grid_sediment_final
+
+END MODULE MOD_Grid_RiverLakeSediment
+#endif
+```
+
+**Step 2: 提交**
+
+```bash
+git add main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+git commit -m "feat: create MOD_Grid_RiverLakeSediment module skeleton"
+```
+
+---
+
+### Task 1.5: 添加模块到 Makefile
+
+**Files:**
+- Modify: `Makefile`
+
+**Step 1: 查找 HYDRO 模块编译规则**
+
+```bash
+grep -n "MOD_Grid_RiverLake" Makefile | head -10
+```
+
+**Step 2: 添加泥沙模块编译规则**
+
+在相应位置添加：
+
+```makefile
+$(OBJS_DIR)/MOD_Grid_RiverLakeSediment.o: main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+	$(FC) -c $(FOPTS) $(INCLUDE_DIR) -o $@ $<
+```
+
+并将 `$(OBJS_DIR)/MOD_Grid_RiverLakeSediment.o` 添加到依赖列表中。
+
+**Step 3: 提交**
+
+```bash
+git add Makefile
+git commit -m "build: add MOD_Grid_RiverLakeSediment to Makefile"
+```
+
+---
+
+## Phase 2: 静态数据读取
+
+### Task 2.1: 实现维度读取
+
+**Files:**
+- Modify: `main/HYDRO/MOD_Grid_RiverLakeSediment.F90`
+
+**Step 1: 添加维度读取子程序**
+
+在 `grid_sediment_init` 中添加：
+
+```fortran
+   SUBROUTINE grid_sediment_init()
+   USE MOD_NetCDFSerial
+   USE MOD_Grid_RiverLakeNetwork, only: numucat, totalnumucat, &
+      ucat_data_address, topo_rivwth, topo_rivlen
+   IMPLICIT NONE
+
+   character(len=256) :: parafile
+   integer :: i
+
+      IF (.not. DEF_USE_SEDIMENT) RETURN
+
+      ! Set parameters from namelist
+      lambda    = DEF_SED_LAMBDA
+      lyrdph    = DEF_SED_LYRDPH
+      psedD     = DEF_SED_DENSITY
+      pwatD     = DEF_SED_WATER_DENSITY
+      visKin    = DEF_SED_VISKIN
+      vonKar    = DEF_SED_VONKAR
+      totlyrnum = DEF_SED_TOTLYRNUM
+      pyld      = DEF_SED_PYLD
+      pyldc     = DEF_SED_PYLDC
+      pyldpc    = DEF_SED_PYLDPC
+      dsylunit  = DEF_SED_DSYLUNIT
+
+      parafile = DEF_UnitCatchment_file
+
+      ! Read dimensions from NetCDF file
+      IF (p_is_master) THEN
+         CALL ncio_inquire_length(parafile, 'sed_n', nsed)
+         CALL ncio_inquire_length(parafile, 'slope_layers', nlfp_sed)
+      ENDIF
+
+#ifdef USEMPI
+      CALL mpi_bcast(nsed, 1, MPI_INTEGER, p_address_master, p_comm_glb, p_err)
+      CALL mpi_bcast(nlfp_sed, 1, MPI_INTEGER, p_address_master, p_comm_glb, p_err)
+#endif
+
+      WRITE(*,*) 'Sediment module: nsed=', nsed, ' nlfp_sed=', nlfp_sed
+
+      ! Parse grain diameters from string
+      CALL parse_grain_diameters()
+
+      ! Calculate settling velocities
+      CALL calc_settling_velocities()
+
+      ! Read static data
+      CALL read_sediment_static_data(parafile)
+
+      ! Allocate and initialize state variables
+      CALL allocate_sediment_vars()
+
+      ! Initialize state from sed_frc
+      CALL initialize_sediment_state()
+
+   END SUBROUTINE grid_sediment_init
+```
+
+**Step 2: 提交**
+
+```bash
+git add main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+git commit -m "feat: implement sediment dimension reading"
+```
+
+---
+
+### Task 2.2: 实现粒径解析
+
+**Files:**
+- Modify: `main/HYDRO/MOD_Grid_RiverLakeSediment.F90`
+
+**Step 1: 添加粒径解析子程序**
+
+```fortran
+   SUBROUTINE parse_grain_diameters()
+   ! Parse grain diameters from comma-separated string
+   IMPLICIT NONE
+   character(len=256) :: str
+   integer :: i, j, k, n
+
+      allocate(sDiam(nsed))
+      str = trim(adjustl(DEF_SED_DIAMETER))
+
+      n = 0
+      j = 1
+      DO i = 1, len_trim(str)
+         IF (str(i:i) == ',' .or. i == len_trim(str)) THEN
+            n = n + 1
+            IF (i == len_trim(str)) THEN
+               k = i
+            ELSE
+               k = i - 1
+            ENDIF
+            IF (n <= nsed) THEN
+               read(str(j:k), *) sDiam(n)
+            ENDIF
+            j = i + 1
+         ENDIF
+      ENDDO
+
+      IF (n /= nsed) THEN
+         WRITE(*,*) 'WARNING: Number of diameters does not match nsed'
+         WRITE(*,*) '  Parsed:', n, ' Expected:', nsed
+      ENDIF
+
+      WRITE(*,*) 'Grain diameters (m):', sDiam
+
+   END SUBROUTINE parse_grain_diameters
+```
+
+**Step 2: 提交**
+
+```bash
+git add main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+git commit -m "feat: implement grain diameter parsing"
+```
+
+---
+
+### Task 2.3: 实现沉降速度计算
+
+**Files:**
+- Modify: `main/HYDRO/MOD_Grid_RiverLakeSediment.F90`
+
+**Step 1: 添加沉降速度计算子程序**
+
+从 `cmf_ctrl_sed_mod.F90` 移植：
+
+```fortran
+   SUBROUTINE calc_settling_velocities()
+   ! Calculate settling velocity using Stokes-Rubey formula
+   USE MOD_Const_Physical, only: grav
+   IMPLICIT NONE
+   real(r8) :: sTmp
+   integer :: i
+
+      allocate(setvel(nsed))
+
+      DO i = 1, nsed
+         sTmp = 6.0_r8 * visKin / sDiam(i)
+         setvel(i) = sqrt(2.0_r8/3.0_r8 * (psedD-pwatD)/pwatD * grav * sDiam(i) &
+                    + sTmp*sTmp) - sTmp
+      ENDDO
+
+      WRITE(*,*) 'Settling velocities (m/s):', setvel
+
+   END SUBROUTINE calc_settling_velocities
+```
+
+**Step 2: 提交**
+
+```bash
+git add main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+git commit -m "feat: implement settling velocity calculation"
+```
+
+---
+
+### Task 2.4: 实现静态数据读取
+
+**Files:**
+- Modify: `main/HYDRO/MOD_Grid_RiverLakeSediment.F90`
+
+**Step 1: 添加静态数据读取子程序**
+
+使用与 `MOD_Grid_RiverLakeNetwork` 相同的模式：
+
+```fortran
+   SUBROUTINE read_sediment_static_data(parafile)
+   USE MOD_Grid_RiverLakeNetwork, only: numucat, readin_riverlake_parameter
+   IMPLICIT NONE
+   character(len=*), intent(in) :: parafile
+
+      IF (p_is_worker) THEN
+         IF (numucat > 0) THEN
+            allocate(sed_frc  (nsed, numucat))
+            allocate(sed_slope(nlfp_sed, numucat))
+         ENDIF
+      ENDIF
+
+      ! Read sediment fraction
+      CALL readin_riverlake_parameter(parafile, 'sed_frc', rdata2d=sed_frc)
+
+      ! Read sediment slope
+      CALL readin_riverlake_parameter(parafile, 'sed_slope', rdata2d=sed_slope)
+
+      ! Normalize sed_frc (ensure sum = 1)
+      CALL normalize_sed_frc()
+
+   END SUBROUTINE read_sediment_static_data
+
+   SUBROUTINE normalize_sed_frc()
+   USE MOD_Grid_RiverLakeNetwork, only: numucat
+   IMPLICIT NONE
+   integer :: i
+   real(r8) :: frc_sum
+
+      IF (.not. p_is_worker) RETURN
+      IF (numucat <= 0) RETURN
+
+      DO i = 1, numucat
+         frc_sum = sum(sed_frc(:,i))
+         IF (frc_sum > 0._r8) THEN
+            sed_frc(:,i) = sed_frc(:,i) / frc_sum
+         ELSE
+            sed_frc(:,i) = 1._r8 / real(nsed, r8)
+         ENDIF
+      ENDDO
+
+   END SUBROUTINE normalize_sed_frc
+```
+
+**Step 2: 提交**
+
+```bash
+git add main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+git commit -m "feat: implement sediment static data reading"
+```
+
+---
+
+### Task 2.5: 实现变量分配与初始化
+
+**Files:**
+- Modify: `main/HYDRO/MOD_Grid_RiverLakeSediment.F90`
+
+**Step 1: 添加变量分配子程序**
+
+```fortran
+   SUBROUTINE allocate_sediment_vars()
+   USE MOD_Grid_RiverLakeNetwork, only: numucat
+   IMPLICIT NONE
+
+      IF (.not. p_is_worker) RETURN
+      IF (numucat <= 0) RETURN
+
+      ! State variables
+      allocate(sedcon(nsed, numucat))
+      allocate(layer (nsed, numucat))
+      allocate(seddep(nsed, totlyrnum, numucat))
+
+      ! Diagnostic variables
+      allocate(sedout      (nsed, numucat))
+      allocate(bedout      (nsed, numucat))
+      allocate(sedinp      (nsed, numucat))
+      allocate(netflw      (nsed, numucat))
+      allocate(shearvel    (numucat))
+      allocate(critshearvel(nsed, numucat))
+      allocate(susvel      (nsed, numucat))
+
+      ! Accumulation variables
+      allocate(sed_acc_veloc(numucat))
+      allocate(sed_acc_wdsrf(numucat))
+      allocate(sed_precip   (numucat))
+
+      ! History output variables
+      allocate(a_sedcon  (nsed, numucat))
+      allocate(a_sedout  (nsed, numucat))
+      allocate(a_bedout  (nsed, numucat))
+      allocate(a_sedinp  (nsed, numucat))
+      allocate(a_netflw  (nsed, numucat))
+      allocate(a_layer   (nsed, numucat))
+      allocate(a_shearvel(numucat))
+
+      ! Initialize to zero
+      sedcon       = 0._r8
+      layer        = 0._r8
+      seddep       = 0._r8
+      sedout       = 0._r8
+      bedout       = 0._r8
+      sedinp       = 0._r8
+      netflw       = 0._r8
+      shearvel     = 0._r8
+      critshearvel = 0._r8
+      susvel       = 0._r8
+      sed_acc_veloc = 0._r8
+      sed_acc_wdsrf = 0._r8
+      sed_acc_time  = 0._r8
+      sed_precip    = 0._r8
+      a_sedcon     = 0._r8
+      a_sedout     = 0._r8
+      a_bedout     = 0._r8
+      a_sedinp     = 0._r8
+      a_netflw     = 0._r8
+      a_layer      = 0._r8
+      a_shearvel   = 0._r8
+
+   END SUBROUTINE allocate_sediment_vars
+
+   SUBROUTINE initialize_sediment_state()
+   USE MOD_Grid_RiverLakeNetwork, only: numucat, topo_rivwth, topo_rivlen
+   IMPLICIT NONE
+   integer :: i, ilyr
+
+      IF (.not. p_is_worker) RETURN
+      IF (numucat <= 0) RETURN
+
+      ! Initialize active layer based on sed_frc
+      DO i = 1, numucat
+         layer(:,i) = lyrdph * topo_rivwth(i) * topo_rivlen(i) * sed_frc(:,i)
+
+         ! Initialize deposition layers
+         DO ilyr = 1, totlyrnum - 1
+            seddep(:,ilyr,i) = layer(:,i)
+         ENDDO
+         ! Bottom layer gets extra depth
+         seddep(:,totlyrnum,i) = max(10._r8 - lyrdph*totlyrnum, 0._r8) &
+            * topo_rivwth(i) * topo_rivlen(i) * sed_frc(:,i)
+      ENDDO
+
+   END SUBROUTINE initialize_sediment_state
+```
+
+**Step 2: 提交**
+
+```bash
+git add main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+git commit -m "feat: implement sediment variable allocation and initialization"
+```
+
+---
+
+## Phase 3: 核心物理计算
+
+### Task 3.1: 实现剪切流速计算
+
+**Files:**
+- Modify: `main/HYDRO/MOD_Grid_RiverLakeSediment.F90`
+
+**Step 1: 添加剪切流速计算函数**
+
+```fortran
+   FUNCTION calc_shear_velocity(rivvel, rivdph, rivman) RESULT(svel)
+   ! Calculate shear velocity using Manning's equation
+   USE MOD_Const_Physical, only: grav
+   IMPLICIT NONE
+   real(r8), intent(in) :: rivvel   ! River velocity [m/s]
+   real(r8), intent(in) :: rivdph   ! River depth [m]
+   real(r8), intent(in) :: rivman   ! Manning coefficient
+   real(r8) :: svel
+
+      IF (rivdph > 0._r8) THEN
+         svel = sqrt(grav * rivman**2 * rivvel**2 * rivdph**(-1._r8/3._r8))
+      ELSE
+         svel = 0._r8
+      ENDIF
+
+   END FUNCTION calc_shear_velocity
+```
+
+**Step 2: 提交**
+
+```bash
+git add main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+git commit -m "feat: implement shear velocity calculation"
+```
+
+---
+
+### Task 3.2: 实现临界剪切力计算
+
+**Files:**
+- Modify: `main/HYDRO/MOD_Grid_RiverLakeSediment.F90`
+
+**Step 1: 添加临界剪切力计算函数**
+
+```fortran
+   FUNCTION calc_critical_shear_velocity(diam) RESULT(csvel)
+   ! Calculate critical shear velocity using Shields curve
+   IMPLICIT NONE
+   real(r8), intent(in) :: diam    ! Grain diameter [m]
+   real(r8) :: csvel               ! [(cm/s)^2]
+   real(r8) :: cA, cB
+
+      cB = 1._r8
+      IF (diam >= 0.00303_r8) THEN
+         cA = 80.9_r8
+      ELSEIF (diam >= 0.00118_r8) THEN
+         cA = 134.6_r8
+         cB = 31._r8 / 32._r8
+      ELSEIF (diam >= 0.000565_r8) THEN
+         cA = 55._r8
+      ELSEIF (diam >= 0.000065_r8) THEN
+         cA = 8.41_r8
+         cB = 11._r8 / 32._r8
+      ELSE
+         cA = 226._r8
+      ENDIF
+
+      csvel = cA * (diam * 100._r8) ** cB
+
+   END FUNCTION calc_critical_shear_velocity
+
+   SUBROUTINE calc_critical_shear_egiazoroff(i, svel, csvel_out)
+   ! Calculate critical shear velocity using Egiazoroff equation for mixed-size sediment
+   IMPLICIT NONE
+   integer,  intent(in)  :: i           ! Unit catchment index
+   real(r8), intent(in)  :: svel        ! Shear velocity [m/s]
+   real(r8), intent(out) :: csvel_out(nsed)
+
+   real(r8) :: dMean, csVel0
+   integer  :: ised
+   real(r8) :: layer_sum
+
+      layer_sum = sum(layer(:,i))
+
+      IF (layer_sum <= 0._r8) THEN
+         csvel_out(:) = 1.e20_r8
+         RETURN
+      ENDIF
+
+      ! Calculate mean diameter
+      dMean = 0._r8
+      DO ised = 1, nsed
+         dMean = dMean + sDiam(ised) * layer(ised,i) / layer_sum
+      ENDDO
+
+      csVel0 = calc_critical_shear_velocity(dMean)
+
+      DO ised = 1, nsed
+         IF (sDiam(ised) / dMean >= 0.4_r8) THEN
+            csvel_out(ised) = sqrt(csVel0 * sDiam(ised) / dMean) * &
+               (log10(19._r8) / log10(19._r8 * sDiam(ised) / dMean)) * 0.01_r8
+         ELSE
+            csvel_out(ised) = sqrt(0.85_r8 * csVel0) * 0.01_r8
+         ENDIF
+      ENDDO
+
+   END SUBROUTINE calc_critical_shear_egiazoroff
+```
+
+**Step 2: 提交**
+
+```bash
+git add main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+git commit -m "feat: implement critical shear velocity calculation"
+```
+
+---
+
+### Task 3.3: 实现悬浮速度计算
+
+**Files:**
+- Modify: `main/HYDRO/MOD_Grid_RiverLakeSediment.F90`
+
+**Step 1: 添加悬浮速度计算函数**
+
+```fortran
+   SUBROUTINE calc_suspend_velocity(csvel, svel, susvel_out)
+   ! Calculate suspension velocity using Uchida & Fukuoka (2019) Eq.44
+   IMPLICIT NONE
+   real(r8), intent(in)  :: csvel(nsed)  ! Critical shear velocity [m/s]
+   real(r8), intent(in)  :: svel         ! Shear velocity [m/s]
+   real(r8), intent(out) :: susvel_out(nsed)
+
+   real(r8) :: alpha, a, cB, sTmp
+   integer  :: ised
+
+      alpha = vonKar / 6._r8
+      a = 0.08_r8
+      cB = 1._r8 - lambda
+
+      susvel_out(:) = 0._r8
+
+      DO ised = 1, nsed
+         IF (csvel(ised) > svel) CYCLE
+         IF (svel <= 0._r8) CYCLE
+
+         sTmp = setvel(ised) / alpha / svel
+         susvel_out(ised) = max(setvel(ised) * cB / (1._r8 + sTmp) * &
+            (1._r8 - a*sTmp) / (1._r8 + (1._r8-a)*sTmp), 0._r8)
+      ENDDO
+
+   END SUBROUTINE calc_suspend_velocity
+```
+
+**Step 2: 提交**
+
+```bash
+git add main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+git commit -m "feat: implement suspension velocity calculation"
+```
+
+---
+
+### Task 3.4: 实现平流输运计算
+
+**Files:**
+- Modify: `main/HYDRO/MOD_Grid_RiverLakeSediment.F90`
+
+**Step 1: 添加平流输运计算子程序**
+
+这是最复杂的部分，从 `cmf_ctrl_sed_mod.F90` 的 `calc_advection` 移植：
+
+```fortran
+   SUBROUTINE calc_sediment_advection(dt, rivout, rivsto)
+   ! Calculate suspended sediment and bedload advection
+   USE MOD_Const_Physical, only: grav
+   USE MOD_Grid_RiverLakeNetwork, only: numucat, ucat_next, topo_rivwth
+   USE MOD_WorkerPushData
+   IMPLICIT NONE
+
+   real(r8), intent(in) :: dt           ! Time step [s]
+   real(r8), intent(in) :: rivout(:)    ! River outflow [m3/s]
+   real(r8), intent(in) :: rivsto(:)    ! River storage [m3]
+
+   real(r8), allocatable :: sedsto(:,:)       ! Sediment storage [numucat, nsed]
+   real(r8), allocatable :: bOut(:,:), sOut(:,:)
+   real(r8), allocatable :: brate(:,:), srate(:,:)
+   real(r8), allocatable :: sedcon_next(:,:)
+
+   integer  :: i, ised, i0, i1
+   real(r8) :: plusVel, minusVel
+   real(r8) :: layer_sum
+
+      IF (.not. p_is_worker) RETURN
+      IF (numucat <= 0) RETURN
+
+      allocate(sedsto(nsed, numucat))
+      allocate(bOut  (nsed, numucat))
+      allocate(sOut  (nsed, numucat))
+      allocate(brate (nsed, numucat))
+      allocate(srate (nsed, numucat))
+      allocate(sedcon_next(nsed, numucat))
+
+      ! Calculate sediment storage from concentration
+      DO i = 1, numucat
+         sedsto(:,i) = sedcon(:,i) * max(rivsto(i), 0._r8)
+      ENDDO
+
+      ! Get downstream sediment concentration
+      DO ised = 1, nsed
+         CALL worker_push_data(push_next2ucat, sedcon(ised,:), sedcon_next(ised,:), &
+            fillvalue = 0._r8)
+      ENDDO
+
+      bOut(:,:) = 0._r8
+      sOut(:,:) = 0._r8
+
+      ! Calculate outflows
+      DO i = 1, numucat
+         IF (rivout(i) >= 0._r8) THEN
+            i0 = i
+            i1 = ucat_next(i)
+         ELSE
+            i0 = ucat_next(i)
+            i1 = i
+         ENDIF
+
+         IF (rivout(i) == 0._r8) THEN
+            sedout(:,i) = 0._r8
+            bedout(:,i) = 0._r8
+            CYCLE
+         ENDIF
+
+         ! Suspended sediment outflow
+         IF (i0 < 0) THEN
+            sedout(:,i) = sedcon(:,i1) * rivout(i)
+         ELSE
+            sedout(:,i) = sedcon(:,i0) * rivout(i)
+            sOut(:,i0) = sOut(:,i0) + abs(sedout(:,i)) * dt
+         ENDIF
+
+         ! Bedload outflow
+         layer_sum = sum(layer(:,i))
+         IF (all(critshearvel(:,i) >= shearvel(i)) .or. layer_sum == 0._r8 .or. i0 < 0) THEN
+            bedout(:,i) = 0._r8
+         ELSE
+            DO ised = 1, nsed
+               IF (critshearvel(ised,i) >= shearvel(i) .or. layer(ised,i) == 0._r8) THEN
+                  bedout(ised,i) = 0._r8
+                  CYCLE
+               ENDIF
+               plusVel = shearvel(i) + critshearvel(ised,i)
+               minusVel = shearvel(i) - critshearvel(ised,i)
+               bedout(ised,i) = 17._r8 * topo_rivwth(i) * plusVel * minusVel * minusVel &
+                  / ((psedD-pwatD)/pwatD) / grav * layer(ised,i) / layer_sum
+               IF (i0 > 0) bOut(ised,i0) = bOut(ised,i0) + bedout(ised,i) * dt
+            ENDDO
+         ENDIF
+      ENDDO
+
+      ! Adjust outflow if larger than available storage
+      brate(:,:) = 1._r8
+      srate(:,:) = 1._r8
+
+      DO i = 1, numucat
+         DO ised = 1, nsed
+            IF (sOut(ised,i) > 1.e-8_r8) THEN
+               srate(ised,i) = min(sedsto(ised,i) / sOut(ised,i), 1._r8)
+            ENDIF
+            IF (bOut(ised,i) > 1.e-8_r8) THEN
+               brate(ised,i) = min(layer(ised,i) / bOut(ised,i), 1._r8)
+            ENDIF
+         ENDDO
+      ENDDO
+
+      ! Apply adjusted outflows and update storage
+      DO i = 1, numucat
+         IF (rivout(i) >= 0._r8) THEN
+            i0 = i
+            i1 = ucat_next(i)
+         ELSE
+            i0 = ucat_next(i)
+            i1 = i
+         ENDIF
+
+         IF (i0 > 0) THEN
+            sedout(:,i) = sedout(:,i) * srate(:,i0)
+            sedsto(:,i0) = max(sedsto(:,i0) - abs(sedout(:,i)) * dt, 0._r8)
+            bedout(:,i) = bedout(:,i) * brate(:,i0)
+            layer(:,i0) = max(layer(:,i0) - abs(bedout(:,i)) * dt, 0._r8)
+         ENDIF
+
+         IF (i1 > 0) THEN
+            sedsto(:,i1) = max(sedsto(:,i1) + abs(sedout(:,i)) * dt, 0._r8)
+            layer(:,i1) = max(layer(:,i1) + abs(bedout(:,i)) * dt, 0._r8)
+         ENDIF
+      ENDDO
+
+      ! Update concentration from storage
+      DO i = 1, numucat
+         IF (rivsto(i) > 0._r8) THEN
+            sedcon(:,i) = sedsto(:,i) / rivsto(i)
+         ENDIF
+      ENDDO
+
+      deallocate(sedsto, bOut, sOut, brate, srate, sedcon_next)
+
+   END SUBROUTINE calc_sediment_advection
+```
+
+**Step 2: 提交**
+
+```bash
+git add main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+git commit -m "feat: implement sediment advection calculation"
+```
+
+---
+
+### Task 3.5: 实现悬浮-沉积交换计算
+
+**Files:**
+- Modify: `main/HYDRO/MOD_Grid_RiverLakeSediment.F90`
+
+**Step 1: 添加交换计算子程序**
+
+```fortran
+   SUBROUTINE calc_sediment_exchange(dt, rivsto, rivwth, rivlen)
+   ! Calculate suspension-deposition exchange
+   USE MOD_Grid_RiverLakeNetwork, only: numucat
+   IMPLICIT NONE
+
+   real(r8), intent(in) :: dt
+   real(r8), intent(in) :: rivsto(:)
+   real(r8), intent(in) :: rivwth(:)
+   real(r8), intent(in) :: rivlen(:)
+
+   real(r8) :: Es(nsed), D(nsed), Zd(nsed)
+   real(r8) :: sedsto(nsed), dTmp(nsed)
+   real(r8) :: layer_sum, area, dTmp1
+   integer  :: i, ised
+   real(r8), parameter :: IGNORE_DPH = 0.05_r8
+
+      IF (.not. p_is_worker) RETURN
+      IF (numucat <= 0) RETURN
+
+      DO i = 1, numucat
+         IF (rivsto(i) < rivwth(i) * rivlen(i) * IGNORE_DPH) THEN
+            netflw(:,i) = 0._r8
+            CYCLE
+         ENDIF
+
+         layer_sum = sum(layer(:,i))
+         area = rivwth(i) * rivlen(i)
+
+         ! Calculate entrainment (suspension)
+         IF (layer_sum == 0._r8 .or. all(susvel(:,i) == 0._r8)) THEN
+            Es(:) = 0._r8
+         ELSE
+            Es(:) = susvel(:,i) * (1._r8 - lambda) * area * layer(:,i) / layer_sum
+            Es(:) = max(Es(:), 0._r8)
+         ENDIF
+
+         ! Calculate deposition
+         IF (shearvel(i) == 0._r8 .or. all(setvel(:) == 0._r8)) THEN
+            D(:) = 0._r8
+         ELSE
+            DO ised = 1, nsed
+               Zd(ised) = 6._r8 * setvel(ised) / vonKar / shearvel(i)
+               D(ised) = setvel(ised) * area * sedcon(ised,i) * &
+                  Zd(ised) / (1._r8 - exp(-Zd(ised)))
+            ENDDO
+            D(:) = max(D(:), 0._r8)
+         ENDIF
+
+         netflw(:,i) = Es(:) - D(:)
+
+         ! Apply exchange with mass conservation
+         sedsto(:) = sedcon(:,i) * rivsto(i)
+
+         DO ised = 1, nsed
+            IF (netflw(ised,i) == 0._r8) THEN
+               CYCLE
+            ELSEIF (netflw(ised,i) > 0._r8) THEN
+               ! Suspension: transfer from layer to water
+               dTmp1 = netflw(ised,i) * dt / (1._r8 - lambda)
+               IF (dTmp1 < layer(ised,i)) THEN
+                  layer(ised,i) = layer(ised,i) - dTmp1
+               ELSE
+                  netflw(ised,i) = layer(ised,i) * (1._r8 - lambda) / dt
+                  layer(ised,i) = 0._r8
+               ENDIF
+               sedsto(ised) = sedsto(ised) + netflw(ised,i) * dt
+            ELSE
+               ! Deposition: transfer from water to layer
+               IF (abs(netflw(ised,i)) * dt < sedsto(ised)) THEN
+                  sedsto(ised) = max(sedsto(ised) - abs(netflw(ised,i)) * dt, 0._r8)
+               ELSE
+                  netflw(ised,i) = -sedsto(ised) / dt
+                  sedsto(ised) = 0._r8
+               ENDIF
+               layer(ised,i) = layer(ised,i) + abs(netflw(ised,i)) * dt / (1._r8 - lambda)
+            ENDIF
+         ENDDO
+
+         ! Add erosion input
+         sedsto(:) = sedsto(:) + sedinp(:,i) * dt
+
+         ! Limit concentration to 1%
+         IF (sum(sedsto(:)) > rivsto(i) * 0.01_r8) THEN
+            dTmp(:) = (sum(sedsto(:)) - rivsto(i) * 0.01_r8) * sedsto(:) / sum(sedsto(:))
+            netflw(:,i) = netflw(:,i) - dTmp(:) / dt
+            sedsto(:) = sedsto(:) - dTmp(:)
+            layer(:,i) = layer(:,i) + dTmp(:) / (1._r8 - lambda)
+         ENDIF
+
+         ! Update concentration
+         IF (rivsto(i) > 0._r8) THEN
+            sedcon(:,i) = sedsto(:) / rivsto(i)
+         ENDIF
+      ENDDO
+
+   END SUBROUTINE calc_sediment_exchange
+```
+
+**Step 2: 提交**
+
+```bash
+git add main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+git commit -m "feat: implement suspension-deposition exchange"
+```
+
+---
+
+### Task 3.6: 实现沉积层重分布
+
+**Files:**
+- Modify: `main/HYDRO/MOD_Grid_RiverLakeSediment.F90`
+
+**Step 1: 添加沉积层重分布子程序**
+
+```fortran
+   SUBROUTINE calc_layer_redistribution(rivwth, rivlen)
+   ! Redistribute sediment into vertical bed layers
+   USE MOD_Grid_RiverLakeNetwork, only: numucat
+   IMPLICIT NONE
+
+   real(r8), intent(in) :: rivwth(:)
+   real(r8), intent(in) :: rivlen(:)
+
+   real(r8) :: lyrvol, diff
+   real(r8) :: layerP(nsed), seddepP(totlyrnum+1, nsed), tmp(nsed)
+   integer  :: i, ilyr, jlyr, slyr
+
+      IF (.not. p_is_worker) RETURN
+      IF (numucat <= 0) RETURN
+
+      DO i = 1, numucat
+         lyrvol = lyrdph * rivwth(i) * rivlen(i)
+
+         ! Ensure non-negative values
+         layer(:,i) = max(layer(:,i), 0._r8)
+         seddep(:,:,i) = max(seddep(:,:,i), 0._r8)
+
+         ! If total bed storage less than layer volume
+         IF (sum(layer(:,i)) + sum(seddep(:,:,i)) <= lyrvol) THEN
+            layer(:,i) = layer(:,i) + sum(seddep(:,:,i), dim=2)
+            seddep(:,:,i) = 0._r8
+            CYCLE
+         ENDIF
+
+         ! Distribute into top exchange layer
+         layerP(:) = layer(:,i)
+         IF (sum(layerP(:)) >= lyrvol) THEN
+            layer(:,i) = layerP(:) * min(lyrvol / sum(layerP(:)), 1._r8)
+            layerP(:) = max(layerP(:) - layer(:,i), 0._r8)
+            slyr = 0
+         ELSEIF (sum(seddep(:,:,i)) > 0._r8) THEN
+            layerP(:) = 0._r8
+            DO ilyr = 1, totlyrnum
+               diff = lyrvol - sum(layer(:,i))
+               IF (diff <= 0._r8) EXIT
+               IF (sum(seddep(:,ilyr,i)) <= diff) THEN
+                  layer(:,i) = layer(:,i) + seddep(:,ilyr,i)
+                  seddep(:,ilyr,i) = 0._r8
+                  slyr = ilyr + 1
+               ELSE
+                  tmp(:) = diff * seddep(:,ilyr,i) / sum(seddep(:,ilyr,i))
+                  layer(:,i) = layer(:,i) + tmp(:)
+                  seddep(:,ilyr,i) = max(seddep(:,ilyr,i) - tmp(:), 0._r8)
+                  slyr = ilyr
+                  EXIT
+               ENDIF
+            ENDDO
+         ELSE
+            seddep(:,:,i) = 0._r8
+            CYCLE
+         ENDIF
+
+         IF (sum(seddep(:,:,i)) == 0._r8) CYCLE
+
+         ! Distribute remaining bedload into vertical deposition layers
+         seddepP(1,:) = layerP(:)
+         seddepP(2:,:) = seddep(:,:,i)
+         seddep(:,:,i) = 0._r8
+
+         DO ilyr = 1, totlyrnum - 1
+            IF (sum(seddep(:,ilyr,i)) == lyrvol) CYCLE
+            DO jlyr = slyr + 1, totlyrnum + 1
+               diff = lyrvol - sum(seddep(:,ilyr,i))
+               IF (diff <= 0._r8) EXIT
+               IF (sum(seddepP(jlyr,:)) <= diff) THEN
+                  seddep(:,ilyr,i) = seddep(:,ilyr,i) + seddepP(jlyr,:)
+                  seddepP(jlyr,:) = 0._r8
+               ELSE
+                  tmp(:) = diff * seddepP(jlyr,:) / sum(seddepP(jlyr,:))
+                  seddep(:,ilyr,i) = seddep(:,ilyr,i) + tmp(:)
+                  seddepP(jlyr,:) = max(seddepP(jlyr,:) - tmp(:), 0._r8)
+                  EXIT
+               ENDIF
+            ENDDO
+         ENDDO
+
+         IF (sum(seddepP) > 0._r8) THEN
+            seddep(:,totlyrnum,i) = sum(seddepP, dim=1)
+         ENDIF
+      ENDDO
+
+   END SUBROUTINE calc_layer_redistribution
+```
+
+**Step 2: 提交**
+
+```bash
+git add main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+git commit -m "feat: implement layer redistribution"
+```
+
+---
+
+### Task 3.7: 实现侵蚀产沙计算
+
+**Files:**
+- Modify: `main/HYDRO/MOD_Grid_RiverLakeSediment.F90`
+
+**Step 1: 添加产沙计算子程序**
+
+```fortran
+   SUBROUTINE calc_sediment_yield(fldfrc, grarea)
+   ! Calculate sediment yield from precipitation
+   USE MOD_Grid_RiverLakeNetwork, only: numucat
+   IMPLICIT NONE
+
+   real(r8), intent(in) :: fldfrc(:)   ! Flooded fraction
+   real(r8), intent(in) :: grarea(:)   ! Grid area [m2]
+
+   real(r8) :: precip_mm
+   integer  :: i, ilyr
+
+      IF (.not. p_is_worker) RETURN
+      IF (numucat <= 0) RETURN
+
+      sedinp(:,:) = 0._r8
+
+      DO i = 1, numucat
+         ! Convert precip from mm/s or kg/m2/s to mm/day for threshold
+         precip_mm = sed_precip(i) * 86400._r8
+
+         IF (precip_mm <= 10._r8) CYCLE
+
+         ! Calculate erosion for each floodplain layer
+         DO ilyr = 1, nlfp_sed
+            IF (fldfrc(i) * nlfp_sed > real(ilyr, r8)) CYCLE  ! No erosion if submerged
+
+            sedinp(:,i) = sedinp(:,i) + &
+               pyld * (sed_precip(i) * 3600._r8)**pyldpc * sed_slope(ilyr,i)**pyldc / 3600._r8 &
+               * grarea(i) * min(real(ilyr, r8)/real(nlfp_sed, r8) - fldfrc(i), 1._r8/real(nlfp_sed, r8)) &
+               * dsylunit * sed_frc(:,i)
+         ENDDO
+      ENDDO
+
+   END SUBROUTINE calc_sediment_yield
+```
+
+**Step 2: 提交**
+
+```bash
+git add main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+git commit -m "feat: implement sediment yield calculation"
+```
+
+---
+
+## Phase 4: 模块集成
+
+### Task 4.1: 实现主计算子程序
+
+**Files:**
+- Modify: `main/HYDRO/MOD_Grid_RiverLakeSediment.F90`
+
+**Step 1: 完善 grid_sediment_calc 子程序**
+
+```fortran
+   SUBROUTINE grid_sediment_calc(deltime)
+   USE MOD_Grid_RiverLakeNetwork, only: numucat, topo_rivwth, topo_rivlen, &
+      topo_rivman, topo_area
+   USE MOD_Grid_RiverLakeTimeVars, only: wdsrf_ucat, veloc_riv
+   USE MOD_Grid_RiverLakeHist, only: a_floodarea
+   IMPLICIT NONE
+
+   real(r8), intent(in) :: deltime
+
+   real(r8) :: sed_time_remaining, dt_sed
+   real(r8) :: avg_veloc, avg_wdsrf
+   real(r8), allocatable :: rivsto(:), rivout(:), fldfrc(:)
+   integer  :: i, ised
+
+      IF (.not. DEF_USE_SEDIMENT) RETURN
+      IF (.not. p_is_worker) RETURN
+      IF (numucat <= 0) RETURN
+
+      allocate(rivsto(numucat))
+      allocate(rivout(numucat))
+      allocate(fldfrc(numucat))
+
+      sed_time_remaining = deltime
+
+      DO WHILE (sed_time_remaining > 0._r8)
+
+         dt_sed = min(sed_time_remaining, DEF_SED_DT_MAX)
+
+         ! Calculate average water flow variables
+         IF (sed_acc_time > 0._r8) THEN
+            DO i = 1, numucat
+               avg_veloc = sed_acc_veloc(i) / sed_acc_time
+               avg_wdsrf = sed_acc_wdsrf(i) / sed_acc_time
+
+               ! Calculate shear velocity
+               shearvel(i) = calc_shear_velocity(avg_veloc, avg_wdsrf, topo_rivman(i))
+
+               ! Calculate critical shear velocity (Egiazoroff)
+               CALL calc_critical_shear_egiazoroff(i, shearvel(i), critshearvel(:,i))
+
+               ! Calculate suspension velocity
+               CALL calc_suspend_velocity(critshearvel(:,i), shearvel(i), susvel(:,i))
+
+               ! Estimate river storage and outflow
+               rivsto(i) = avg_wdsrf * topo_rivwth(i) * topo_rivlen(i)
+               rivout(i) = avg_veloc * avg_wdsrf * topo_rivwth(i)
+
+               ! Estimate flooded fraction
+               IF (a_floodarea(i) > 0._r8 .and. topo_area(i) > 0._r8) THEN
+                  fldfrc(i) = a_floodarea(i) / topo_area(i) / sed_acc_time
+               ELSE
+                  fldfrc(i) = 0._r8
+               ENDIF
+            ENDDO
+         ENDIF
+
+         ! Calculate sediment yield from precipitation
+         CALL calc_sediment_yield(fldfrc, topo_area)
+
+         ! Calculate advection
+         CALL calc_sediment_advection(dt_sed, rivout, rivsto)
+
+         ! Calculate suspension-deposition exchange
+         CALL calc_sediment_exchange(dt_sed, rivsto, topo_rivwth, topo_rivlen)
+
+         ! Redistribute bed layers
+         CALL calc_layer_redistribution(topo_rivwth, topo_rivlen)
+
+         ! Accumulate for output
+         CALL accumulate_sediment_output(dt_sed)
+
+         sed_time_remaining = sed_time_remaining - dt_sed
+      ENDDO
+
+      ! Reset accumulation variables
+      sed_acc_time = 0._r8
+      sed_acc_veloc(:) = 0._r8
+      sed_acc_wdsrf(:) = 0._r8
+      sed_precip(:) = 0._r8
+
+      deallocate(rivsto, rivout, fldfrc)
+
+   END SUBROUTINE grid_sediment_calc
+```
+
+**Step 2: 添加累积输出子程序**
+
+```fortran
+   SUBROUTINE accumulate_sediment_output(dt)
+   USE MOD_Grid_RiverLakeNetwork, only: numucat
+   IMPLICIT NONE
+   real(r8), intent(in) :: dt
+   integer :: i
+
+      IF (.not. p_is_worker) RETURN
+      IF (numucat <= 0) RETURN
+
+      DO i = 1, numucat
+         a_sedcon(:,i) = a_sedcon(:,i) + sedcon(:,i) * dt
+         a_sedout(:,i) = a_sedout(:,i) + sedout(:,i) * dt
+         a_bedout(:,i) = a_bedout(:,i) + bedout(:,i) * dt
+         a_sedinp(:,i) = a_sedinp(:,i) + sedinp(:,i) * dt
+         a_netflw(:,i) = a_netflw(:,i) + netflw(:,i) * dt
+         a_layer(:,i)  = a_layer(:,i)  + layer(:,i)  * dt
+         a_shearvel(i) = a_shearvel(i) + shearvel(i) * dt
+      ENDDO
+
+   END SUBROUTINE accumulate_sediment_output
+```
+
+**Step 3: 提交**
+
+```bash
+git add main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+git commit -m "feat: implement main sediment calculation routine"
+```
+
+---
+
+### Task 4.2: 实现诊断累积子程序
+
+**Files:**
+- Modify: `main/HYDRO/MOD_Grid_RiverLakeSediment.F90`
+
+**Step 1: 完善 sediment_diag_accumulate 子程序**
+
+```fortran
+   SUBROUTINE sediment_diag_accumulate(dt, veloc, wdsrf)
+   USE MOD_Grid_RiverLakeNetwork, only: numucat
+   IMPLICIT NONE
+   real(r8), intent(in) :: dt
+   real(r8), intent(in) :: veloc(:)
+   real(r8), intent(in) :: wdsrf(:)
+   integer :: i
+
+      IF (.not. DEF_USE_SEDIMENT) RETURN
+      IF (.not. p_is_worker) RETURN
+      IF (numucat <= 0) RETURN
+
+      sed_acc_time = sed_acc_time + dt
+
+      DO i = 1, numucat
+         sed_acc_veloc(i) = sed_acc_veloc(i) + veloc(i) * dt
+         sed_acc_wdsrf(i) = sed_acc_wdsrf(i) + wdsrf(i) * dt
+      ENDDO
+
+   END SUBROUTINE sediment_diag_accumulate
+```
+
+**Step 2: 完善 sediment_forcing_put 子程序**
+
+```fortran
+   SUBROUTINE sediment_forcing_put(precip)
+   USE MOD_Grid_RiverLakeNetwork, only: numucat
+   IMPLICIT NONE
+   real(r8), intent(in) :: precip(:)
+
+      IF (.not. DEF_USE_SEDIMENT) RETURN
+      IF (.not. p_is_worker) RETURN
+      IF (numucat <= 0) RETURN
+
+      sed_precip(:) = precip(:)
+
+   END SUBROUTINE sediment_forcing_put
+```
+
+**Step 3: 提交**
+
+```bash
+git add main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+git commit -m "feat: implement sediment diagnostic accumulation"
+```
+
+---
+
+### Task 4.3: 在 Flow 模块中添加调用
+
+**Files:**
+- Modify: `main/HYDRO/MOD_Grid_RiverLakeFlow.F90`
+
+**Step 1: 添加模块引用**
+
+在文件开头 USE 语句区域添加：
+
+```fortran
+#ifdef GridRiverLakeSediment
+   USE MOD_Grid_RiverLakeSediment, only: grid_sediment_calc, sediment_diag_accumulate
+#endif
+```
+
+**Step 2: 在水流子循环中添加诊断累积**
+
+在 `DO WHILE (any(dt_res > 0))` 循环内，时间步完成后添加：
+
+```fortran
+            ! ... existing code to update dt_res ...
+            dt_res = dt_res - dt_all
+
+#ifdef GridRiverLakeSediment
+            ! Accumulate water variables for sediment calculation
+            IF (DEF_USE_SEDIMENT) THEN
+               DO i = 1, numucat
+                  IF (ucatfilter(i)) THEN
+                     CALL sediment_diag_accumulate(dt_all(irivsys(i)), &
+                        veloc_riv(i:i), wdsrf_ucat(i:i))
+                  ENDIF
+               ENDDO
+            ENDIF
+#endif
+```
+
+**Step 3: 在水流计算完成后调用泥沙计算**
+
+在 `acctime_rnof = 0.` 之前添加：
+
+```fortran
+#ifdef GridRiverLakeSediment
+      IF (DEF_USE_SEDIMENT) THEN
+         CALL grid_sediment_calc(acctime_rnof_max)
+      ENDIF
+#endif
+```
+
+**Step 4: 提交**
+
+```bash
+git add main/HYDRO/MOD_Grid_RiverLakeFlow.F90
+git commit -m "feat: integrate sediment module into flow calculation"
+```
+
+---
+
+## Phase 5: 历史输出与 Restart
+
+### Task 5.1: 添加泥沙历史输出
+
+**Files:**
+- Modify: `main/HYDRO/MOD_Grid_RiverLakeHist.F90`
+
+**Step 1: 添加模块引用和变量声明**
+
+**Step 2: 在 hist_grid_riverlake_init 中分配泥沙输出变量**
+
+**Step 3: 在 hist_grid_riverlake_out 中写出泥沙变量**
+
+**Step 4: 在 flush_acc_fluxes_riverlake 中重置泥沙累积变量**
+
+**Step 5: 在 hist_grid_riverlake_final 中释放泥沙变量**
+
+**Step 6: 提交**
+
+```bash
+git add main/HYDRO/MOD_Grid_RiverLakeHist.F90
+git commit -m "feat: add sediment history output"
+```
+
+---
+
+### Task 5.2: 添加泥沙 Restart 支持
+
+**Files:**
+- Modify: `main/HYDRO/MOD_Grid_RiverLakeTimeVars.F90`
+
+**Step 1: 在 READ_GridRiverLakeTimeVars 中读取泥沙状态**
+
+**Step 2: 在 WRITE_GridRiverLakeTimeVars 中写出泥沙状态**
+
+**Step 3: 提交**
+
+```bash
+git add main/HYDRO/MOD_Grid_RiverLakeTimeVars.F90
+git commit -m "feat: add sediment restart support"
+```
+
+---
+
+## 验证与测试
+
+### Task 6.1: 编译测试
+
+```bash
+make clean
+make -j4
+```
+
+确保无编译错误。
+
+### Task 6.2: 单点测试
+
+使用小区域配置文件运行，验证：
+1. 泥沙模块正确初始化
+2. 输出变量有合理值
+3. 质量守恒
+
+### Task 6.3: 与 CaMa-Flood 对比
+
+使用相同输入数据，对比：
+1. 悬沙浓度分布
+2. 推移质通量
+3. 沉积层变化
+
+---
+
+## 文件清单
+
+**新建文件：**
+- `main/HYDRO/MOD_Grid_RiverLakeSediment.F90`
+
+**修改文件：**
+- `include/define.h`
+- `main/MOD_Namelist.F90`
+- `main/HYDRO/MOD_Grid_RiverLakeFlow.F90`
+- `main/HYDRO/MOD_Grid_RiverLakeHist.F90`
+- `main/HYDRO/MOD_Grid_RiverLakeTimeVars.F90`
+- `Makefile`

--- a/include/define.h
+++ b/include/define.h
@@ -63,6 +63,12 @@
 #undef GridRiverLakeFlow
 #endif
 
+#define GridRiverLakeSediment
+!    Requires GridRiverLakeFlow
+#ifndef GridRiverLakeFlow
+#undef GridRiverLakeSediment
+#endif
+
 ! 7. If defined, BGC model is used.
 #undef BGC
 

--- a/main/HYDRO/MOD_Grid_RiverLakeFlow.F90
+++ b/main/HYDRO/MOD_Grid_RiverLakeFlow.F90
@@ -18,7 +18,7 @@ MODULE MOD_Grid_RiverLakeFlow
    USE MOD_Grid_RiverLakeHist
 #ifdef GridRiverLakeSediment
    USE MOD_Grid_RiverLakeSediment, only: grid_sediment_init, grid_sediment_calc, &
-      sediment_diag_accumulate, sediment_forcing_put
+      sediment_diag_accumulate, sediment_diag_accumulate_time, sediment_forcing_put
 #endif
    IMPLICIT NONE
 
@@ -620,10 +620,12 @@ CONTAINS
             IF (DEF_USE_SEDIMENT) THEN
                DO i = 1, numucat
                   IF (ucatfilter(i)) THEN
-                     CALL sediment_diag_accumulate(dt_all(irivsys(i)), &
-                        veloc_riv(i:i), wdsrf_ucat(i:i))
+                     CALL sediment_diag_accumulate(dt_all(irivsys(i)), i, &
+                        veloc_riv(i), wdsrf_ucat(i))
                   ENDIF
                ENDDO
+               ! Accumulate time once per sub-timestep (use max dt across all river systems)
+               CALL sediment_diag_accumulate_time(maxval(dt_all))
             ENDIF
 #endif
 

--- a/main/HYDRO/MOD_Grid_RiverLakeFlow.F90
+++ b/main/HYDRO/MOD_Grid_RiverLakeFlow.F90
@@ -177,8 +177,8 @@ CONTAINS
             CALL worker_push_data (push_inpm2ucat, prcp_gd, prcp_uc, &
                fillvalue = 0., mode = 'sum')
 
-            ! Pass precipitation to sediment module [mm/s]
-            CALL sediment_forcing_put(prcp_uc)
+            ! Pass precipitation to sediment module [mm/s], accumulated over time
+            CALL sediment_forcing_put(prcp_uc, deltime)
 
             IF (allocated(prcp_pch)) deallocate(prcp_pch)
             IF (allocated(prcp_gd))  deallocate(prcp_gd)

--- a/main/HYDRO/MOD_Grid_RiverLakeHist.F90
+++ b/main/HYDRO/MOD_Grid_RiverLakeHist.F90
@@ -655,7 +655,9 @@ CONTAINS
 
             DO ised = 1, nsed
                WHERE (acctime_ucat > 0.)
-                  a_sedcon_avg(ised,:) = a_sedcon(ised,:) / acctime_ucat
+                  ! Convert sedcon from volumetric [m³/m³] to mass [kg/m³]
+                  ! sedcon × psedD [g/cm³] × 1000 [kg/m³ per g/cm³]
+                  a_sedcon_avg(ised,:) = a_sedcon(ised,:) / acctime_ucat * DEF_SED_DENSITY * 1000._r8
                   a_sedout_avg(ised,:) = a_sedout(ised,:) / acctime_ucat
                   a_bedout_avg(ised,:) = a_bedout(ised,:) / acctime_ucat
                   a_sedinp_avg(ised,:) = a_sedinp(ised,:) / acctime_ucat

--- a/main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+++ b/main/HYDRO/MOD_Grid_RiverLakeSediment.F90
@@ -39,8 +39,8 @@ MODULE MOD_Grid_RiverLakeSediment
    !-------------------------------------------------------------------------------------
    ! Static Data (read from DEF_UnitCatchment_file)
    !-------------------------------------------------------------------------------------
-   real(r8), allocatable :: sed_frc   (:,:)    ! Sediment fraction [numucat, nsed]
-   real(r8), allocatable :: sed_slope (:,:)    ! Floodplain slope [numucat, nlfp]
+   real(r8), allocatable :: sed_frc   (:,:)    ! Sediment fraction [nsed, numucat]
+   real(r8), allocatable :: sed_slope (:,:)    ! Floodplain slope [nlfp_sed, numucat]
    real(r8), allocatable :: sDiam     (:)      ! Grain diameter [nsed]
    real(r8), allocatable :: setvel    (:)      ! Settling velocity [nsed]
 

--- a/main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+++ b/main/HYDRO/MOD_Grid_RiverLakeSediment.F90
@@ -336,11 +336,10 @@ CONTAINS
    !-------------------------------------------------------------------------------------
    SUBROUTINE allocate_sediment_vars()
    ! Allocate sediment state and diagnostic variables
-   ! TO BE IMPLEMENTED IN TASK 2.5
    !-------------------------------------------------------------------------------------
    USE MOD_Grid_RiverLakeNetwork, only: numucat
    IMPLICIT NONE
-      ! Placeholder stub
+
       IF (.not. p_is_worker) RETURN
       IF (numucat <= 0) RETURN
 
@@ -395,20 +394,16 @@ CONTAINS
       a_layer      = 0._r8
       a_shearvel   = 0._r8
 
-      IF (p_is_io) THEN
-         WRITE(*,*) 'WARNING: allocate_sediment_vars is a placeholder stub'
-      ENDIF
    END SUBROUTINE allocate_sediment_vars
 
    !-------------------------------------------------------------------------------------
    SUBROUTINE initialize_sediment_state()
    ! Initialize sediment state from sed_frc
-   ! TO BE IMPLEMENTED IN TASK 2.5
    !-------------------------------------------------------------------------------------
    USE MOD_Grid_RiverLakeNetwork, only: numucat, topo_rivwth, topo_rivlen
    IMPLICIT NONE
    integer :: i, ilyr
-      ! Placeholder stub
+
       IF (.not. p_is_worker) RETURN
       IF (numucat <= 0) RETURN
 
@@ -425,9 +420,6 @@ CONTAINS
             * topo_rivwth(i) * topo_rivlen(i) * sed_frc(:,i)
       ENDDO
 
-      IF (p_is_io) THEN
-         WRITE(*,*) 'WARNING: initialize_sediment_state is a placeholder stub'
-      ENDIF
    END SUBROUTINE initialize_sediment_state
 
    !-------------------------------------------------------------------------------------

--- a/main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+++ b/main/HYDRO/MOD_Grid_RiverLakeSediment.F90
@@ -47,20 +47,20 @@ MODULE MOD_Grid_RiverLakeSediment
    !-------------------------------------------------------------------------------------
    ! State Variables
    !-------------------------------------------------------------------------------------
-   real(r8), allocatable :: sedcon  (:,:)      ! Suspended sediment concentration [numucat, nsed]
-   real(r8), allocatable :: layer   (:,:)      ! Active layer storage [numucat, nsed]
-   real(r8), allocatable :: seddep  (:,:,:)    ! Deposition layer storage [numucat, totlyrnum, nsed]
+   real(r8), allocatable :: sedcon  (:,:)      ! Suspended sediment concentration [nsed, numucat]
+   real(r8), allocatable :: layer   (:,:)      ! Active layer storage [nsed, numucat]
+   real(r8), allocatable :: seddep  (:,:,:)    ! Deposition layer storage [nsed, totlyrnum, numucat]
 
    !-------------------------------------------------------------------------------------
    ! Diagnostic Variables
    !-------------------------------------------------------------------------------------
-   real(r8), allocatable :: sedout  (:,:)      ! Suspended sediment outflow [numucat, nsed]
-   real(r8), allocatable :: bedout  (:,:)      ! Bedload outflow [numucat, nsed]
-   real(r8), allocatable :: sedinp  (:,:)      ! Erosion input [numucat, nsed]
-   real(r8), allocatable :: netflw  (:,:)      ! Net exchange flux [numucat, nsed]
+   real(r8), allocatable :: sedout  (:,:)      ! Suspended sediment outflow [nsed, numucat]
+   real(r8), allocatable :: bedout  (:,:)      ! Bedload outflow [nsed, numucat]
+   real(r8), allocatable :: sedinp  (:,:)      ! Erosion input [nsed, numucat]
+   real(r8), allocatable :: netflw  (:,:)      ! Net exchange flux [nsed, numucat]
    real(r8), allocatable :: shearvel(:)        ! Shear velocity [numucat]
-   real(r8), allocatable :: critshearvel(:,:)  ! Critical shear velocity [numucat, nsed]
-   real(r8), allocatable :: susvel  (:,:)      ! Suspension velocity [numucat, nsed]
+   real(r8), allocatable :: critshearvel(:,:)  ! Critical shear velocity [nsed, numucat]
+   real(r8), allocatable :: susvel  (:,:)      ! Suspension velocity [nsed, numucat]
 
    !-------------------------------------------------------------------------------------
    ! Accumulated Variables for Sediment Time-stepping

--- a/main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+++ b/main/HYDRO/MOD_Grid_RiverLakeSediment.F90
@@ -1,0 +1,166 @@
+#include <define.h>
+
+#ifdef GridRiverLakeSediment
+MODULE MOD_Grid_RiverLakeSediment
+!-------------------------------------------------------------------------------------
+! DESCRIPTION:
+!
+!   Sediment transport module for GridRiverLakeFlow.
+!   Ported from CaMa-Flood sediment module (cmf_ctrl_sed_mod.F90)
+!
+! Created by: Claude Code, Dec 2025
+!-------------------------------------------------------------------------------------
+
+   USE MOD_Precision
+   USE MOD_SPMD_Task
+   USE MOD_Namelist
+   IMPLICIT NONE
+
+   !-------------------------------------------------------------------------------------
+   ! Module Parameters
+   !-------------------------------------------------------------------------------------
+   integer,  save :: nsed           ! Number of sediment size classes
+   integer,  save :: totlyrnum      ! Number of deposition layers
+   integer,  save :: nlfp_sed       ! Number of floodplain layers for slope
+
+   real(r8), save :: lambda         ! Porosity [-]
+   real(r8), save :: lyrdph         ! Active layer depth [m]
+   real(r8), save :: psedD          ! Sediment density [g/cm3]
+   real(r8), save :: pwatD          ! Water density [g/cm3]
+   real(r8), save :: visKin         ! Kinematic viscosity [m2/s]
+   real(r8), save :: vonKar         ! Von Karman coefficient [-]
+
+   ! Sediment yield parameters
+   real(r8), save :: pyld           ! Yield coefficient
+   real(r8), save :: pyldc          ! Slope exponent
+   real(r8), save :: pyldpc         ! Precipitation exponent
+   real(r8), save :: dsylunit       ! Unit conversion factor
+
+   !-------------------------------------------------------------------------------------
+   ! Static Data (read from DEF_UnitCatchment_file)
+   !-------------------------------------------------------------------------------------
+   real(r8), allocatable :: sed_frc   (:,:)    ! Sediment fraction [numucat, nsed]
+   real(r8), allocatable :: sed_slope (:,:)    ! Floodplain slope [numucat, nlfp]
+   real(r8), allocatable :: sDiam     (:)      ! Grain diameter [nsed]
+   real(r8), allocatable :: setvel    (:)      ! Settling velocity [nsed]
+
+   !-------------------------------------------------------------------------------------
+   ! State Variables
+   !-------------------------------------------------------------------------------------
+   real(r8), allocatable :: sedcon  (:,:)      ! Suspended sediment concentration [numucat, nsed]
+   real(r8), allocatable :: layer   (:,:)      ! Active layer storage [numucat, nsed]
+   real(r8), allocatable :: seddep  (:,:,:)    ! Deposition layer storage [numucat, totlyrnum, nsed]
+
+   !-------------------------------------------------------------------------------------
+   ! Diagnostic Variables
+   !-------------------------------------------------------------------------------------
+   real(r8), allocatable :: sedout  (:,:)      ! Suspended sediment outflow [numucat, nsed]
+   real(r8), allocatable :: bedout  (:,:)      ! Bedload outflow [numucat, nsed]
+   real(r8), allocatable :: sedinp  (:,:)      ! Erosion input [numucat, nsed]
+   real(r8), allocatable :: netflw  (:,:)      ! Net exchange flux [numucat, nsed]
+   real(r8), allocatable :: shearvel(:)        ! Shear velocity [numucat]
+   real(r8), allocatable :: critshearvel(:,:)  ! Critical shear velocity [numucat, nsed]
+   real(r8), allocatable :: susvel  (:,:)      ! Suspension velocity [numucat, nsed]
+
+   !-------------------------------------------------------------------------------------
+   ! Accumulated Variables for Sediment Time-stepping
+   !-------------------------------------------------------------------------------------
+   real(r8), save :: sed_acc_time              ! Accumulated time for averaging
+   real(r8), allocatable :: sed_acc_veloc(:)   ! Accumulated velocity [numucat]
+   real(r8), allocatable :: sed_acc_wdsrf(:)   ! Accumulated water depth [numucat]
+   real(r8), allocatable :: sed_precip(:)      ! Precipitation for sediment yield [numucat]
+
+   !-------------------------------------------------------------------------------------
+   ! Accumulated Variables for History Output
+   !-------------------------------------------------------------------------------------
+   real(r8), allocatable :: a_sedcon  (:,:)    ! Accumulated sedcon
+   real(r8), allocatable :: a_sedout  (:,:)    ! Accumulated sedout
+   real(r8), allocatable :: a_bedout  (:,:)    ! Accumulated bedout
+   real(r8), allocatable :: a_sedinp  (:,:)    ! Accumulated sedinp
+   real(r8), allocatable :: a_netflw  (:,:)    ! Accumulated netflw
+   real(r8), allocatable :: a_layer   (:,:)    ! Accumulated layer
+   real(r8), allocatable :: a_shearvel(:)      ! Accumulated shearvel
+
+   !-------------------------------------------------------------------------------------
+   ! Public Subroutines
+   !-------------------------------------------------------------------------------------
+   PUBLIC :: grid_sediment_init
+   PUBLIC :: grid_sediment_calc
+   PUBLIC :: grid_sediment_final
+   PUBLIC :: sediment_diag_accumulate
+   PUBLIC :: sediment_forcing_put
+
+CONTAINS
+
+   !-------------------------------------------------------------------------------------
+   SUBROUTINE grid_sediment_init()
+   ! Initialize sediment module
+   !-------------------------------------------------------------------------------------
+   IMPLICIT NONE
+      ! Placeholder - to be implemented
+      WRITE(*,*) 'MOD_Grid_RiverLakeSediment: grid_sediment_init called'
+   END SUBROUTINE grid_sediment_init
+
+   !-------------------------------------------------------------------------------------
+   SUBROUTINE grid_sediment_calc(deltime)
+   ! Main sediment calculation routine
+   !-------------------------------------------------------------------------------------
+   IMPLICIT NONE
+   real(r8), intent(in) :: deltime
+      ! Placeholder - to be implemented
+      WRITE(*,*) 'MOD_Grid_RiverLakeSediment: grid_sediment_calc called, dt=', deltime
+   END SUBROUTINE grid_sediment_calc
+
+   !-------------------------------------------------------------------------------------
+   SUBROUTINE sediment_diag_accumulate(dt, veloc, wdsrf)
+   ! Accumulate water flow variables for sediment calculation
+   !-------------------------------------------------------------------------------------
+   IMPLICIT NONE
+   real(r8), intent(in) :: dt
+   real(r8), intent(in) :: veloc(:)
+   real(r8), intent(in) :: wdsrf(:)
+      ! Placeholder - to be implemented
+   END SUBROUTINE sediment_diag_accumulate
+
+   !-------------------------------------------------------------------------------------
+   SUBROUTINE sediment_forcing_put(precip)
+   ! Store precipitation for sediment yield calculation
+   !-------------------------------------------------------------------------------------
+   IMPLICIT NONE
+   real(r8), intent(in) :: precip(:)
+      ! Placeholder - to be implemented
+   END SUBROUTINE sediment_forcing_put
+
+   !-------------------------------------------------------------------------------------
+   SUBROUTINE grid_sediment_final()
+   ! Cleanup sediment module
+   !-------------------------------------------------------------------------------------
+   IMPLICIT NONE
+      IF (allocated(sed_frc     )) deallocate(sed_frc     )
+      IF (allocated(sed_slope   )) deallocate(sed_slope   )
+      IF (allocated(sDiam       )) deallocate(sDiam       )
+      IF (allocated(setvel      )) deallocate(setvel      )
+      IF (allocated(sedcon      )) deallocate(sedcon      )
+      IF (allocated(layer       )) deallocate(layer       )
+      IF (allocated(seddep      )) deallocate(seddep      )
+      IF (allocated(sedout      )) deallocate(sedout      )
+      IF (allocated(bedout      )) deallocate(bedout      )
+      IF (allocated(sedinp      )) deallocate(sedinp      )
+      IF (allocated(netflw      )) deallocate(netflw      )
+      IF (allocated(shearvel    )) deallocate(shearvel    )
+      IF (allocated(critshearvel)) deallocate(critshearvel)
+      IF (allocated(susvel      )) deallocate(susvel      )
+      IF (allocated(sed_acc_veloc)) deallocate(sed_acc_veloc)
+      IF (allocated(sed_acc_wdsrf)) deallocate(sed_acc_wdsrf)
+      IF (allocated(sed_precip  )) deallocate(sed_precip  )
+      IF (allocated(a_sedcon    )) deallocate(a_sedcon    )
+      IF (allocated(a_sedout    )) deallocate(a_sedout    )
+      IF (allocated(a_bedout    )) deallocate(a_bedout    )
+      IF (allocated(a_sedinp    )) deallocate(a_sedinp    )
+      IF (allocated(a_netflw    )) deallocate(a_netflw    )
+      IF (allocated(a_layer     )) deallocate(a_layer     )
+      IF (allocated(a_shearvel  )) deallocate(a_shearvel  )
+   END SUBROUTINE grid_sediment_final
+
+END MODULE MOD_Grid_RiverLakeSediment
+#endif

--- a/main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+++ b/main/HYDRO/MOD_Grid_RiverLakeSediment.F90
@@ -194,15 +194,42 @@ CONTAINS
    !-------------------------------------------------------------------------------------
    SUBROUTINE parse_grain_diameters()
    ! Parse grain diameters from comma-separated string
-   ! TO BE IMPLEMENTED IN TASK 2.2
    !-------------------------------------------------------------------------------------
    IMPLICIT NONE
-      ! Placeholder stub
+   character(len=256) :: str
+   integer :: i, j, k, n
+
       allocate(sDiam(nsed))
-      sDiam(:) = 0.001_r8  ! Default 1mm
-      IF (p_is_io) THEN
-         WRITE(*,*) 'WARNING: parse_grain_diameters is a placeholder stub'
+      str = trim(adjustl(DEF_SED_DIAMETER))
+
+      n = 0
+      j = 1
+      DO i = 1, len_trim(str)
+         IF (str(i:i) == ',' .or. i == len_trim(str)) THEN
+            n = n + 1
+            IF (i == len_trim(str)) THEN
+               k = i
+            ELSE
+               k = i - 1
+            ENDIF
+            IF (n <= nsed) THEN
+               read(str(j:k), *) sDiam(n)
+            ENDIF
+            j = i + 1
+         ENDIF
+      ENDDO
+
+      IF (n /= nsed) THEN
+         IF (p_is_io) THEN
+            WRITE(*,*) 'WARNING: Number of diameters does not match nsed'
+            WRITE(*,*) '  Parsed:', n, ' Expected:', nsed
+         ENDIF
       ENDIF
+
+      IF (p_is_io) THEN
+         WRITE(*,*) 'Grain diameters (m):', sDiam
+      ENDIF
+
    END SUBROUTINE parse_grain_diameters
 
    !-------------------------------------------------------------------------------------

--- a/main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+++ b/main/HYDRO/MOD_Grid_RiverLakeSediment.F90
@@ -423,6 +423,25 @@ CONTAINS
    END SUBROUTINE initialize_sediment_state
 
    !-------------------------------------------------------------------------------------
+   FUNCTION calc_shear_velocity(rivvel, rivdph, rivman) RESULT(svel)
+   ! Calculate shear velocity using Manning's equation
+   !-------------------------------------------------------------------------------------
+   USE MOD_Const_Physical, only: grav
+   IMPLICIT NONE
+   real(r8), intent(in) :: rivvel   ! River velocity [m/s]
+   real(r8), intent(in) :: rivdph   ! River depth [m]
+   real(r8), intent(in) :: rivman   ! Manning coefficient
+   real(r8) :: svel
+
+      IF (rivdph > 0._r8) THEN
+         svel = sqrt(grav * rivman**2 * rivvel**2 * rivdph**(-1._r8/3._r8))
+      ELSE
+         svel = 0._r8
+      ENDIF
+
+   END FUNCTION calc_shear_velocity
+
+   !-------------------------------------------------------------------------------------
    SUBROUTINE grid_sediment_final()
    ! Cleanup sediment module
    !-------------------------------------------------------------------------------------

--- a/main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+++ b/main/HYDRO/MOD_Grid_RiverLakeSediment.F90
@@ -509,6 +509,35 @@ CONTAINS
    END SUBROUTINE calc_critical_shear_egiazoroff
 
    !-------------------------------------------------------------------------------------
+   SUBROUTINE calc_suspend_velocity(csvel, svel, susvel_out)
+   ! Calculate suspension velocity using Uchida & Fukuoka (2019) Eq.44
+   !-------------------------------------------------------------------------------------
+   IMPLICIT NONE
+   real(r8), intent(in)  :: csvel(nsed)  ! Critical shear velocity [m/s]
+   real(r8), intent(in)  :: svel         ! Shear velocity [m/s]
+   real(r8), intent(out) :: susvel_out(nsed)
+
+   real(r8) :: alpha, a, cB, sTmp
+   integer  :: ised
+
+      alpha = vonKar / 6._r8
+      a = 0.08_r8
+      cB = 1._r8 - lambda
+
+      susvel_out(:) = 0._r8
+
+      DO ised = 1, nsed
+         IF (csvel(ised) > svel) CYCLE
+         IF (svel <= 0._r8) CYCLE
+
+         sTmp = setvel(ised) / alpha / svel
+         susvel_out(ised) = max(setvel(ised) * cB / (1._r8 + sTmp) * &
+            (1._r8 - a*sTmp) / (1._r8 + (1._r8-a)*sTmp), 0._r8)
+      ENDDO
+
+   END SUBROUTINE calc_suspend_velocity
+
+   !-------------------------------------------------------------------------------------
    SUBROUTINE grid_sediment_final()
    ! Cleanup sediment module
    !-------------------------------------------------------------------------------------

--- a/main/HYDRO/MOD_Grid_RiverLakeSediment.F90
+++ b/main/HYDRO/MOD_Grid_RiverLakeSediment.F90
@@ -255,15 +255,24 @@ CONTAINS
    !-------------------------------------------------------------------------------------
    SUBROUTINE calc_settling_velocities()
    ! Calculate settling velocity using Stokes-Rubey formula
-   ! TO BE IMPLEMENTED IN TASK 2.3
    !-------------------------------------------------------------------------------------
+   USE MOD_Const_Physical, only: grav
    IMPLICIT NONE
-      ! Placeholder stub
+   real(r8) :: sTmp
+   integer :: i
+
       allocate(setvel(nsed))
-      setvel(:) = 0.001_r8  ! Default settling velocity
+
+      DO i = 1, nsed
+         sTmp = 6.0_r8 * visKin / sDiam(i)
+         setvel(i) = sqrt(2.0_r8/3.0_r8 * (psedD-pwatD)/pwatD * grav * sDiam(i) &
+                    + sTmp*sTmp) - sTmp
+      ENDDO
+
       IF (p_is_io) THEN
-         WRITE(*,*) 'WARNING: calc_settling_velocities is a placeholder stub'
+         WRITE(*,*) 'Settling velocities (m/s):', setvel
       ENDIF
+
    END SUBROUTINE calc_settling_velocities
 
    !-------------------------------------------------------------------------------------

--- a/run/China_Grid_30km_IGBP_VG_CaMa.nml
+++ b/run/China_Grid_30km_IGBP_VG_CaMa.nml
@@ -63,6 +63,11 @@
    DEF_HIST_FREQ = 'DAILY' ! write history file frequency: HOURLY/DAILY/MONTHLY/YEARLY
    DEF_HIST_groupby = 'DAY' ! history in one file: DAY/MONTH/YEAR
    DEF_HIST_mode = 'one' ! history in one or block
+
+   ! Sediment module configuration
+   DEF_USE_SEDIMENT = .true.
+   DEF_UnitCatchment_file = '/Users/zhongwangwei/Desktop/Github/pycama/output/Global15min2/Initialization/grid_routing_data.nc'
+
    DEF_REST_CompressLevel = 1
    DEF_HIST_CompressLevel = 1
 

--- a/share/MOD_Namelist.F90
+++ b/share/MOD_Namelist.F90
@@ -974,6 +974,15 @@ MODULE MOD_Namelist
       logical :: qresv_in                         = .true.
       logical :: qresv_out                        = .true.
 
+      logical :: sedcon                           = .true.
+      logical :: sedout                           = .true.
+      logical :: bedout                           = .true.
+      logical :: sedinp                           = .true.
+      logical :: netflw                           = .true.
+      logical :: sedlayer                         = .true.
+      logical :: shearvel                         = .false.
+      logical :: critshear                        = .false.
+
       logical :: sensors                          = .true.
 
    END type history_var_type
@@ -2386,6 +2395,15 @@ CONTAINS
       CALL sync_hist_vars_one (DEF_hist_vars%volresv     , set_defaults)
       CALL sync_hist_vars_one (DEF_hist_vars%qresv_in    , set_defaults)
       CALL sync_hist_vars_one (DEF_hist_vars%qresv_out   , set_defaults)
+
+      CALL sync_hist_vars_one (DEF_hist_vars%sedcon      , set_defaults)
+      CALL sync_hist_vars_one (DEF_hist_vars%sedout      , set_defaults)
+      CALL sync_hist_vars_one (DEF_hist_vars%bedout      , set_defaults)
+      CALL sync_hist_vars_one (DEF_hist_vars%sedinp      , set_defaults)
+      CALL sync_hist_vars_one (DEF_hist_vars%netflw      , set_defaults)
+      CALL sync_hist_vars_one (DEF_hist_vars%sedlayer    , set_defaults)
+      CALL sync_hist_vars_one (DEF_hist_vars%shearvel    , set_defaults)
+      CALL sync_hist_vars_one (DEF_hist_vars%critshear   , set_defaults)
 
       CALL sync_hist_vars_one (DEF_hist_vars%sensors     , set_defaults)
 

--- a/share/MOD_Namelist.F90
+++ b/share/MOD_Namelist.F90
@@ -321,6 +321,22 @@ MODULE MOD_Namelist
    integer :: DEF_Reservoir_Method = 0
    real(r8) :: DEF_GRIDBASED_ROUTING_MAX_DT = 3600.
 
+   ! ----- sediment module -----
+   logical :: DEF_USE_SEDIMENT = .false.
+   real(r8) :: DEF_SED_LAMBDA = 0.4
+   real(r8) :: DEF_SED_LYRDPH = 0.00005
+   real(r8) :: DEF_SED_DENSITY = 2.65
+   real(r8) :: DEF_SED_WATER_DENSITY = 1.0
+   real(r8) :: DEF_SED_VISKIN = 1.0e-6
+   real(r8) :: DEF_SED_VONKAR = 0.4
+   integer :: DEF_SED_TOTLYRNUM = 5
+   real(r8) :: DEF_SED_DT_MAX = 3600.
+   character(len=256) :: DEF_SED_DIAMETER = "0.0002,0.002,0.02"
+   real(r8) :: DEF_SED_PYLD = 0.01
+   real(r8) :: DEF_SED_PYLDC = 2.0
+   real(r8) :: DEF_SED_PYLDPC = 2.0
+   real(r8) :: DEF_SED_DSYLUNIT = 1.0e-6
+
    ! ----- others -----
    character(len=5)   :: DEF_precip_phase_discrimination_scheme = 'II'
 
@@ -1103,6 +1119,21 @@ CONTAINS
       DEF_Reservoir_Method,                   &
       DEF_GRIDBASED_ROUTING_MAX_DT,           &
 
+      DEF_USE_SEDIMENT,                       &
+      DEF_SED_LAMBDA,                         &
+      DEF_SED_LYRDPH,                         &
+      DEF_SED_DENSITY,                        &
+      DEF_SED_WATER_DENSITY,                  &
+      DEF_SED_VISKIN,                         &
+      DEF_SED_VONKAR,                         &
+      DEF_SED_TOTLYRNUM,                      &
+      DEF_SED_DT_MAX,                         &
+      DEF_SED_DIAMETER,                       &
+      DEF_SED_PYLD,                           &
+      DEF_SED_PYLDC,                          &
+      DEF_SED_PYLDPC,                         &
+      DEF_SED_DSYLUNIT,                       &
+
       DEF_precip_phase_discrimination_scheme, &
 
       DEF_USE_SoilInit,                       &
@@ -1713,6 +1744,21 @@ CONTAINS
       CALL mpi_bcast (DEF_USE_EstimatedRiverDepth            ,1   ,mpi_logical   ,p_address_master ,p_comm_glb ,p_err)
       CALL mpi_bcast (DEF_Reservoir_Method                   ,1   ,mpi_integer   ,p_address_master ,p_comm_glb ,p_err)
       CALL mpi_bcast (DEF_GRIDBASED_ROUTING_MAX_DT           ,1   ,mpi_real8     ,p_address_master ,p_comm_glb ,p_err)
+
+      CALL mpi_bcast (DEF_USE_SEDIMENT                       ,1   ,mpi_logical   ,p_address_master ,p_comm_glb ,p_err)
+      CALL mpi_bcast (DEF_SED_LAMBDA                         ,1   ,mpi_real8     ,p_address_master ,p_comm_glb ,p_err)
+      CALL mpi_bcast (DEF_SED_LYRDPH                         ,1   ,mpi_real8     ,p_address_master ,p_comm_glb ,p_err)
+      CALL mpi_bcast (DEF_SED_DENSITY                        ,1   ,mpi_real8     ,p_address_master ,p_comm_glb ,p_err)
+      CALL mpi_bcast (DEF_SED_WATER_DENSITY                  ,1   ,mpi_real8     ,p_address_master ,p_comm_glb ,p_err)
+      CALL mpi_bcast (DEF_SED_VISKIN                         ,1   ,mpi_real8     ,p_address_master ,p_comm_glb ,p_err)
+      CALL mpi_bcast (DEF_SED_VONKAR                         ,1   ,mpi_real8     ,p_address_master ,p_comm_glb ,p_err)
+      CALL mpi_bcast (DEF_SED_TOTLYRNUM                      ,1   ,mpi_integer   ,p_address_master ,p_comm_glb ,p_err)
+      CALL mpi_bcast (DEF_SED_DT_MAX                         ,1   ,mpi_real8     ,p_address_master ,p_comm_glb ,p_err)
+      CALL mpi_bcast (DEF_SED_DIAMETER                       ,256 ,mpi_character ,p_address_master ,p_comm_glb ,p_err)
+      CALL mpi_bcast (DEF_SED_PYLD                           ,1   ,mpi_real8     ,p_address_master ,p_comm_glb ,p_err)
+      CALL mpi_bcast (DEF_SED_PYLDC                          ,1   ,mpi_real8     ,p_address_master ,p_comm_glb ,p_err)
+      CALL mpi_bcast (DEF_SED_PYLDPC                         ,1   ,mpi_real8     ,p_address_master ,p_comm_glb ,p_err)
+      CALL mpi_bcast (DEF_SED_DSYLUNIT                       ,1   ,mpi_real8     ,p_address_master ,p_comm_glb ,p_err)
 
       CALL mpi_bcast (DEF_HISTORY_IN_VECTOR                  ,1   ,mpi_logical   ,p_address_master ,p_comm_glb ,p_err)
 


### PR DESCRIPTION
## Summary

Ported sediment transport module from CaMa-Flood to GridRiverLakeFlow framework.

### Features
- **Suspended sediment transport**: Advection with water flow
- **Bedload transport**: Meyer-Peter Müller formula
- **Sediment yield**: Precipitation-driven erosion (Sunada & Hasegawa 1993)
- **Suspension-deposition exchange**: Rouse profile based
- **Active layer and deposition layers**: Vertical bed structure

### Key files
- `main/HYDRO/MOD_Grid_RiverLakeSediment.F90` - Main sediment module (~1060 lines)
- `include/define.h` - Added `#define GridRiverLakeSediment`
- `share/MOD_Namelist.F90` - Added 14 namelist parameters
- Integration with `MOD_Grid_RiverLakeFlow.F90`, `MOD_Grid_RiverLakeHist.F90`, `MOD_Grid_RiverLakeTimeVars.F90`

### Namelist parameters
```fortran
DEF_USE_SEDIMENT = .true.           ! Enable sediment module
DEF_SED_DIAMETER = "0.0002,0.002,0.02"  ! Grain diameters [m]
DEF_SED_LAMBDA = 0.4                ! Porosity
DEF_SED_DENSITY = 2.65              ! Sediment density [g/cm3]
DEF_SED_PYLD = 0.01                 ! Yield coefficient
...
```

### Static data requirements
- `sed_frc(nsed, numucat)` - Sediment fraction per size class
- `sed_slope(nlfp_sed, numucat)` - Floodplain slope

## Test plan
- [ ] Compile with `#define GridRiverLakeSediment`
- [ ] Verify static data reading from DEF_UnitCatchment_file
- [ ] Run simulation and check sediment output variables
- [ ] Verify restart file read/write